### PR TITLE
Feature/875

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,7 +16,7 @@
 #
 ###
 
-runtime: custom
+runtime: python27
 module: mvm
 api_version: 1
 threadsafe: true

--- a/app.yaml
+++ b/app.yaml
@@ -16,7 +16,7 @@
 #
 ###
 
-runtime: python27
+runtime: custom
 module: mvm
 api_version: 1
 threadsafe: true

--- a/google_helpers/logging_service.py
+++ b/google_helpers/logging_service.py
@@ -17,7 +17,6 @@ limitations under the License.
 """
 
 from oauth2client.client import SignedJwtAssertionCredentials
-from oauth2client.client import GoogleCredentials
 from googleapiclient.discovery import build
 from httplib2 import Http
 from django.conf import settings

--- a/google_helpers/reports_service.py
+++ b/google_helpers/reports_service.py
@@ -1,0 +1,45 @@
+"""
+
+Copyright 2015, Institute for Systems Biology
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from oauth2client.client import SignedJwtAssertionCredentials
+from googleapiclient import discovery
+from django.conf import settings
+from httplib2 import Http
+
+
+PEM_FILE = settings.PEM_FILE
+CLIENT_EMAIL = settings.CLIENT_EMAIL
+
+
+def get_reports_resource():
+
+    client_email = CLIENT_EMAIL
+    with open(PEM_FILE) as f:
+        private_key = f.read()
+
+    credentials = SignedJwtAssertionCredentials(
+        client_email,
+        private_key,
+        scope='https://www.googleapis.com/auth/admin.reports.audit.readonly',
+        sub='kelly@isb-cgc.org'
+        )
+
+    http_auth = credentials.authorize(Http())
+
+    service = discovery.build('admin', 'reports_v1', http=http_auth)
+    return service, http_auth

--- a/scripts/add_site_ids.py
+++ b/scripts/add_site_ids.py
@@ -18,7 +18,10 @@ limitations under the License.
 
 import os
 import MySQLdb
+import logging
 from GenespotRE import secret_settings
+
+logging.basicConfig(level=logging.INFO)
 
 db_settings = secret_settings.get('DATABASE')['default']
 ssl = None
@@ -36,3 +39,5 @@ cursor = db.cursor()
 cursor.execute(delete_str)
 cursor.execute(insert_str, insert_tuple)
 db.commit()
+
+cursor.close()

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -179,7 +179,7 @@ def write_log_entry(log_name, log_message):
         type log_message: json
         param log_message: The struct/json payload
     """
-    client = get_logging_resource()
+    client, http_auth = get_logging_resource()
 
     # write using logging API (metadata)
     entry_metadata = {

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -40,6 +40,7 @@ from django.conf import settings
 from googleapiclient import http
 from googleapiclient.errors import HttpError
 from google_helpers.directory_service import get_directory_resource
+from google_helpers.reports_service import get_reports_resource
 from google_helpers.storage_service import get_storage_resource
 from google_helpers.resourcemanager_service import get_crm_resource
 from google_helpers.logging_service import get_logging_resource
@@ -442,7 +443,7 @@ def create_and_log_reports(request):
     """
 
     # construct service.
-    service = get_directory_resource()
+    service, http_auth = get_reports_resource()
 
     # get utc time and timedelta
     utc_now = datetime.datetime.utcnow()
@@ -451,19 +452,19 @@ def create_and_log_reports(request):
 
     #reports return account information about different types of administrator activity events.
     admin_report = service.activities().list(userKey='all', applicationName='admin',
-                                             startTime=start_datetime).execute()
+                                             startTime=start_datetime).execute(http=http_auth)
 
     # reports return account information about different types of Login activity events.
     login_report = service.activities().list(userKey='all', applicationName='login',
-                                             startTime=start_datetime).execute()
+                                             startTime=start_datetime).execute(http=http_auth)
 
     # reports return account information about different types of Token activity events.
     token_report = service.activities().list(userKey='all', applicationName='token',
-                                             startTime=start_datetime).execute()
+                                             startTime=start_datetime).execute(http=http_auth)
 
     #reports return information about various Groups activity events.
     groups_report = service.activities().list(userKey='all', applicationName='groups',
-                                              startTime=start_datetime).execute()
+                                              startTime=start_datetime).execute(http=http_auth)
 
     # log the reports using Cloud logging API
     write_log_entry('apps_admin_activity_report', admin_report)

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -27,7 +27,7 @@ import pytz
 import pysftp
 
 import pexpect  # comment this out when running in gae
-from datetime import datetime
+import datetime
 
 from django.http import HttpResponse
 from django.contrib.auth.models import User
@@ -182,7 +182,7 @@ def write_log_entry(log_name, log_message):
 
     # write using logging API (metadata)
     entry_metadata = {
-        "timestamp": datetime.utcnow().isoformat("T") + "Z",
+        "timestamp": datetime.datetime.utcnow().isoformat("T") + "Z",
         "serviceName": "compute.googleapis.com",
         "severity": "INFO",
         "labels": {}
@@ -225,7 +225,7 @@ def check_user_login(request):
 
             expire_time = nih_user.NIH_assertion_expiration
             expire_time = expire_time if expire_time.tzinfo is not None else pytz.utc.localize(expire_time)
-            now_in_utc = pytz.utc.localize(datetime.now())
+            now_in_utc = pytz.utc.localize(datetime.datetime.now())
 
             if (expire_time - now_in_utc).total_seconds() <= 0:
                 # take user off ACL_GOOGLE_GROUP, without bothering to check if user is dbGaP_authorized or not
@@ -269,7 +269,7 @@ def is_very_expired(login_datetime):
 
 
 def is_expired(login_datetime, expiry_padding_seconds=0):
-    return (pytz.utc.localize(datetime.now()) - login_datetime).total_seconds() >= (LOGIN_EXPIRATION_SECONDS + expiry_padding_seconds)
+    return (pytz.utc.localize(datetime.datetime.now()) - login_datetime).total_seconds() >= (LOGIN_EXPIRATION_SECONDS + expiry_padding_seconds)
 
 
 # given a list of CSV rows, test whether any of those rows contain the specified
@@ -445,7 +445,7 @@ def create_and_log_reports(request):
     service = get_directory_resource()
 
     # get utc time and timedelta
-    utc_now = datetime.utcnow()
+    utc_now = datetime.datetime.utcnow()
     tdelta = utc_now + datetime.timedelta(days=-7)
     start_datetime = tdelta.isoformat("T") + "Z" # collect last 7 days logs
 


### PR DESCRIPTION
tasks/create_and_log_reports works locally -- there was more to change than I thought, particularly with the `google_helpers/logging_service.py` file. The documentation says `GoogleCredentials.get_application_default()` works for the logging API but it appears we need to use `SignedJwtAssertionCredentials`.