### PR TITLE
cohort_id to integer in GET RESOURCE for cohorts_list and cohort_pati…

### DIFF
--- a/api/Cohort.py
+++ b/api/Cohort.py
@@ -221,7 +221,7 @@ Cohort_Endpoints = endpoints.api(name='cohort_api', version='v1', description="G
 class Cohort_Endpoints_API(remote.Service):
 
 
-    GET_RESOURCE = endpoints.ResourceContainer(token=messages.StringField(1), cohort_id=messages.StringField(2))
+    GET_RESOURCE = endpoints.ResourceContainer(token=messages.StringField(1), cohort_id=messages.IntegerField(2))
     @endpoints.method(GET_RESOURCE, CohortsList,
                       path='cohorts_list', http_method='GET', name='cohorts.list')
     def cohorts_list(self, request):
@@ -318,7 +318,7 @@ class Cohort_Endpoints_API(remote.Service):
             raise endpoints.NotFoundException("Authentication failed.")
 
 
-    GET_RESOURCE = endpoints.ResourceContainer(cohort_id=messages.StringField(1, required=True),
+    GET_RESOURCE = endpoints.ResourceContainer(cohort_id=messages.IntegerField(1, required=True),
                                                token=messages.StringField(2))
     @endpoints.method(GET_RESOURCE, CohortPatientsSamplesList,
                       path='cohort_patients_samples_list', http_method='GET', name='cohorts.cohort_patients_samples_list')
@@ -337,9 +337,6 @@ class Cohort_Endpoints_API(remote.Service):
             user_email = get_user_email_from_token(access_token)
 
         cohort_id = request.__getattribute__('cohort_id')
-
-        if not cohort_id.isdigit():
-            raise endpoints.NotFoundException("Cohort_id must be an integer. You entered {}.".format(cohort_id))
 
         if user_email:
             django.setup()


### PR DESCRIPTION
some endpoints had `cohort_id=messages.StringField` as input and some had `cohort_id=messages.IntegerField` so I changed two endpoints to the latter. Yan's suggestion.