### PR TITLE
Feature/1105

### DIFF
--- a/api/seqpeek_view_api.py
+++ b/api/seqpeek_view_api.py
@@ -81,7 +81,7 @@ class SeqPeekTrackRecord(Message):
 
 class SeqPeekViewPlotDataRecord(Message):
     tracks = MessageField(SeqPeekTrackRecord, 1, repeated=True)
-    protein = MessageField(InterproItem, 2, required=True)
+    protein = MessageField(InterproItem, 2, required=False)
     regions = MessageField(SeqPeekRegionRecord, 3, repeated=True)
 
 
@@ -175,22 +175,28 @@ class SeqPeekViewDataAccessAPI(remote.Service):
 
             maf_data_vector = maf_data_result[gnab_feature_id]['data']
 
-            # Since the gene (hugo_symbol) parameter is part of the GNAB feature ID,
-            # it will be sanity-checked in the SeqPeekMAFDataAccess instance.
-            seqpeek_data = SeqPeekMAFDataFormatter().format_maf_vector_for_view(maf_data_vector, cohort_id_array)
+            if len(maf_data_vector) > 0:
+                # Since the gene (hugo_symbol) parameter is part of the GNAB feature ID,
+                # it will be sanity-checked in the SeqPeekMAFDataAccess instance.
+                seqpeek_data = SeqPeekMAFDataFormatter().format_maf_vector_for_view(maf_data_vector, cohort_id_array)
 
-            seqpeek_maf_vector = seqpeek_data.maf_vector
-            seqpeek_cohort_info = seqpeek_data.cohort_info
-            removed_row_statistics_dict = seqpeek_data.removed_row_statistics
+                seqpeek_maf_vector = seqpeek_data.maf_vector
+                seqpeek_cohort_info = seqpeek_data.cohort_info
+                removed_row_statistics_dict = seqpeek_data.removed_row_statistics
 
-            seqpeek_view_data = SeqPeekViewDataBuilder().build_view_data(hugo_symbol,
-                                                                         seqpeek_maf_vector,
-                                                                         seqpeek_cohort_info,
-                                                                         cohort_id_array,
-                                                                         removed_row_statistics_dict)
+                seqpeek_view_data = SeqPeekViewDataBuilder().build_view_data(hugo_symbol,
+                                                                             seqpeek_maf_vector,
+                                                                             seqpeek_cohort_info,
+                                                                             cohort_id_array,
+                                                                             removed_row_statistics_dict)
 
-            response = self.create_response(seqpeek_view_data)
-            return response
+                response = self.create_response(seqpeek_view_data)
+                return response
+            else:
+                # No data found
+                return SeqPeekViewRecord(plot_data=SeqPeekViewPlotDataRecord(tracks=[], protein=None, regions=[]),
+                                         hugo_symbol=hugo_symbol, cohort_id_list=[str(i) for i in cohort_id_array],
+                                         removed_row_statistics=[])
         except Exception as e:
             logging.exception(e)
             raise InternalServerErrorException()

--- a/bq_data_access/seqpeek/seqpeek_view.py
+++ b/bq_data_access/seqpeek/seqpeek_view.py
@@ -232,7 +232,9 @@ class SeqPeekViewDataBuilder(object):
             label, cohort_size = get_track_label_and_cohort_information(track[TRACK_ID_FIELD], cohort_info_map)
             track['label'] = label
 
-        plot_data['tracks'].append(build_summary_track(plot_data['tracks']))
+        # Display the "combined" track only if more than one cohort is visualized
+        if len(cohort_id_list) >= 2:
+            plot_data['tracks'].append(build_summary_track(plot_data['tracks']))
 
         for track in plot_data['tracks']:
             # Calculate statistics

--- a/bq_data_access/seqpeek_maf_data.py
+++ b/bq_data_access/seqpeek_maf_data.py
@@ -64,11 +64,6 @@ class SeqPeekDataProvider(GNABFeatureProvider):
 
         skip_count = 0
         for row in query_result_array:
-            #uniprot_aapos = row['f'][4]['v']
-            #if uniprot_aapos is None:
-            #    skip_count += 1
-            #    continue
-
             result.append({
                 'patient_id': row['f'][0]['v'],
                 'sample_id': row['f'][1]['v'],
@@ -79,7 +74,6 @@ class SeqPeekDataProvider(GNABFeatureProvider):
                 'uniprot_id': row['f'][6]['v'],
             })
 
-        logging.debug(str(result[0]))
         logging.debug("Query result is {qrows} rows, skipped {skipped} rows".format(qrows=len(query_result_array),
                                                                                     skipped=skip_count))
         return result

--- a/static/js/seqpeek_view/seqpeek_view.js
+++ b/static/js/seqpeek_view/seqpeek_view.js
@@ -5,6 +5,10 @@ define([
     SeqPeekViewFactory
 ) {
     return {
+        render_no_data_message: function(target_element, gene_label) {
+            $('<h3>No data found for gene ' + gene_label + '</h3>').appendTo(target_element);
+        },
+
         render_seqpeek_legend: function(target_element) {
             var MUTATION_TYPE_COLOR_MAP = {
                 Nonsense_Mutation: "#71C560",

--- a/static/js/visualizations/plotFactory.js
+++ b/static/js/visualizations/plotFactory.js
@@ -245,16 +245,24 @@ define([
 
     function generate_seqpeek_plot(plot_selector, legend_selector, view_data) {
         var plot_data = view_data['plot_data'];
+        var hugo_symbol = view_data['hugo_symbol'];
+
         var element = $(plot_selector)[0];
 
-        seqpeek_view.render_seqpeek_legend(legend_selector);
+        if (plot_data.hasOwnProperty('tracks')) {
+            seqpeek_view.render_seqpeek_legend(legend_selector);
 
-        // Render a HTML table for the visualization. Each track will be in a separate <tr> element.
-        var seqpeek_el = seqpeek_view.render_seqpeek_template(element, view_data['hugo_symbol'], plot_data['tracks']);
-        var table_selector = seqpeek_el.table;
-        var gene_element = seqpeek_el.gene_element;
+            // Render a HTML table for the visualization. Each track will be in a separate <tr> element.
+            var seqpeek_el = seqpeek_view.render_seqpeek_template(element, hugo_symbol, plot_data['tracks']);
+            var table_selector = seqpeek_el.table;
+            var gene_element = seqpeek_el.gene_element;
 
-        seqpeek_view.render_seqpeek(table_selector, gene_element, view_data);
+            seqpeek_view.render_seqpeek(table_selector, gene_element, view_data);
+        }
+        else {
+            // No data was found for the gene and cohorts
+            seqpeek_view.render_no_data_message(plot_selector, hugo_symbol);
+        }
     }
 
     /*


### PR DESCRIPTION
* The ```combined``` track is displayed only if more than one cohort are visualized
* Modified SeqPeek endpoint to return no ```tracks``` if no data is found
* Added "no data found" message to SeqPeek visualization