### PR TITLE
Bugfix #1192

### DIFF
--- a/static/js/libs/d3.parsets.js
+++ b/static/js/libs/d3.parsets.js
@@ -514,9 +514,10 @@
         };
 
         var body = d3.select("body");
-        var tooltip = body.append("div")
+        // s-paquette@ISB: Don't remake the tooltip DOM object if it's already there
+        var tooltip = (!d3.select(".parsets-tooltip").empty() ? d3.select(".parsets-tooltip") : body.append("div")
             .style("display", "none")
-            .attr("class", "parsets-tooltip");
+            .attr("class", "parsets-tooltip"));
 
         // copies event.on to parsets.on and returns parsets
         return d3.rebind(parsets, event, "on").value(1).width(width).height(height);//height was once 600);

--- a/static/js/visualizations/createBarGraph.js
+++ b/static/js/visualizations/createBarGraph.js
@@ -18,6 +18,17 @@
 
 define (['jquery', 'd3', 'd3tip', 'vizhelpers'],
 function($, d3, d3tip, vizhelpers) {
+
+    // If you want to override the tip coming in from the create call,
+    // do it here
+    var barTip = d3tip()
+        .attr('class', 'd3-tip')
+        .direction('n')
+        .offset([0, 0])
+        .html(function(d) {
+            return d.count;
+        });
+
     return {
 
         dataCounts: function(data, x_attr) {
@@ -42,13 +53,7 @@ function($, d3, d3tip, vizhelpers) {
             return results;
         },
         createBarGraph: function(svg, raw_Data, width, height, bar_width,  x_attr, xLabel, tip, margin, legend) {
-            var tip = d3tip()
-                .attr('class', 'd3-tip')
-                .direction('n')
-                .offset([0, 0])
-                .html(function(d) {
-                    return d.count;
-                });
+            tip = barTip || tip;
             var data = this.dataCounts(raw_Data, x_attr);
             var plot_width = (bar_width+5) * data.length;
 

--- a/static/js/visualizations/createCubbyPlot.js
+++ b/static/js/visualizations/createCubbyPlot.js
@@ -18,6 +18,16 @@
 
 define (['jquery', 'd3', 'd3tip', 'vizhelpers'],
 function($, d3, d3tip, vizhelpers) {
+    
+    var tip = d3tip()
+        .attr('class', 'd3-tip')
+        .direction('n')
+        .offset([0, 0])
+        .html(function(d) {
+        return '<span>log<sub>2</sub>(true counts / expected counts)</span><br/>'
+                + '<span>log<sub>2</sub>(' + d['total'] + ' / ' + d['expected_total'].toFixed(4) + ')</span>'
+        });
+
     return {
         data_totals: function(data, x_attr, y_attr, x_domain, y_domain) {
             var results_dict = {};
@@ -273,15 +283,6 @@ function($, d3, d3tip, vizhelpers) {
                 .style('opacity', '0');
 
             zoom_area.call(zoom);
-
-            var tip = d3tip()
-                    .attr('class', 'd3-tip')
-                    .direction('n')
-                    .offset([0, 0])
-                    .html(function(d) {
-                    return '<span>log<sub>2</sub>(true counts / expected counts)</span><br/>'
-                            + '<span>log<sub>2</sub>(' + d['total'] + ' / ' + d['expected_total'].toFixed(4) + ')</span>'
-                    });
 
             plot_area.selectAll('.expected_fill')
                 .data(data_counts)

--- a/static/js/visualizations/createHistogram.js
+++ b/static/js/visualizations/createHistogram.js
@@ -31,8 +31,15 @@ function($, d3, d3tip, helpers) {
     var min_n;
     var max_n;
 
+    // If you want to override the tip coming in from the create call,
+    // do it here
+    var histoTip = null;
+
     return {
         createHistogramPlot : function (svg_param, raw_Data, values_only, width_param, height_param, x_attr, xLabel, tip, margin_param, legend) {
+
+            tip = histoTip || tip;
+
             svg    = svg_param;
             width  = width_param;
             height = height_param;

--- a/static/js/visualizations/createScatterPlot.js
+++ b/static/js/visualizations/createScatterPlot.js
@@ -16,8 +16,8 @@
  *
  */
 
-define (['jquery', 'd3', 'd3tip', 'vizhelpers'],
-function($, d3, d3tip, vizhelpers) {
+define (['jquery', 'd3', 'vizhelpers'],
+function($, d3, vizhelpers) {
     var helpers = Object.create(vizhelpers, {});
     return {
         create_scatterplot: function(svg, data, domain, range, xLabel, yLabel, xParam, yParam, colorBy, legend, width, height, cohort_set) {

--- a/static/js/visualizations/createStackedBarchart.js
+++ b/static/js/visualizations/createStackedBarchart.js
@@ -18,6 +18,20 @@
 
 define (['jquery', 'd3', 'd3tip', 'vis_helpers'],
 function($, d3, d3tip, vis_helpers) {
+
+    // There is only one tooltip, generated when this module is first loaded
+    var tip = d3tip()
+        .attr('class', 'd3-tip')
+        .direction('n')
+        .offset([0, 0])
+        .html(function (d) {
+            var str = "";
+            if (d.x == "0") {
+                str = "";
+            }
+            return '<span>' + d.name + ': ' + d.value + '</span>';
+        });
+
     return {
         draw_stacked_mutations: function(data) {
             var gene_list = [
@@ -115,18 +129,6 @@ function($, d3, d3tip, vis_helpers) {
                 .attr('class', 'gene')
                 .attr('transform', function (d, i) {
                     return 'translate(' + (i * x.rangeBand()) + ', 0)';
-                });
-
-            var tip = d3tip()
-                .attr('class', 'd3-tip')
-                .direction('n')
-                .offset([0, 0])
-                .html(function (d) {
-                    var str = "";
-                    if (d.x == "0") {
-                        str = "";
-                    }
-                    return '<span>' + d.name + ': ' + d.value + '</span>';
                 });
 
             var rect = gene.selectAll('rect')

--- a/static/js/visualizations/createTreeGraph.js
+++ b/static/js/visualizations/createTreeGraph.js
@@ -19,6 +19,16 @@
 define(['jquery', 'd3', 'd3tip', 'vis_helpers'],
 function($, d3, d3tip, vis_helpers) {
 
+    // If you want to override the tip coming in from the create call,
+    // do it here
+     var treeTip = d3tip()
+        .attr('class', 'd3-tip')
+        .direction('s')
+        .offset([0, 0])
+        .html(function(d) {
+            return '<span>' + d.name + ': ' + d.count + '</span>';
+        });
+
     return {
         get_treemap_ready: function(data, attribute) {
             var children = [];
@@ -28,15 +38,8 @@ function($, d3, d3tip, vis_helpers) {
             return {children: children, name: attribute};
         },
         draw_tree: function(data, svg, attribute, w, h, showtext, tip) {
-            if (!tip) {
-                tip = d3tip()
-                    .attr('class', 'd3-tip')
-                    .direction('s')
-                    .offset([0, 0])
-                    .html(function(d) {
-                        return '<span>' + d.name + ': ' + d.count + '</span>';
-                    });
-            }
+
+            tip = treeTip || tip;
 
             var node = this.get_treemap_ready(data, attribute);
             var treemap = d3.layout.treemap()

--- a/static/js/visualizations/createViolinPlot.js
+++ b/static/js/visualizations/createViolinPlot.js
@@ -16,8 +16,8 @@
  *
  */
 
-define (['jquery', 'd3', 'd3tip', 'vizhelpers'],
-function($, d3, d3tip, vizhelpers) {
+define (['jquery', 'd3', 'vizhelpers'],
+function($, d3, vizhelpers) {
     var helpers = Object.create(vizhelpers, {});
     return {
         addViolin: function (svg, raw_data, values_only, height, width, domain, range) {


### PR DESCRIPTION
These tooltip optimizations should stop tooltips from getting 'stuck' in display, and the bugfix for D3.parsesets should prevent it from making extra tooltip DOM objects.