### PR TITLE
Loglines, again

### DIFF
--- a/api/metadata.py
+++ b/api/metadata.py
@@ -29,6 +29,7 @@ from cohorts.models import Cohort_Perms,  Cohort as Django_Cohort,Patients, Samp
 from projects.models import Study, User_Feature_Definitions, User_Feature_Counts, User_Data_Tables
 from django.core.signals import request_finished
 import django
+import sys
 import logging
 import re
 import json


### PR DESCRIPTION
It's still not logging our debug lines. More in #1249 about that. The stderr print statements were also not going through, I think because there was no import.sys in api/metadata.py (but mysteriously it works in the dev environment anyways). So, once more, with feeling.