### PR TITLE
Active worksheet will now be respected in browser history

### DIFF
--- a/static/js/workbooks.js
+++ b/static/js/workbooks.js
@@ -185,6 +185,22 @@ require([
         $(this).parent().prev('.worksheet-nav').toggleClass('closed');
     });
 
+    // Adjust the browser history to note what sheet we were on
+    // when we leave this page, so that if a user comes back via
+    // history traversal, the right sheet will be active
+    $(window).on('beforeunload',function(e){
+        var selSheetAttr = $('li.active>a').attr('href');
+        var selSheetId = selSheetAttr.substring(selSheetAttr.indexOf("#")+1);
+        var url = window.location.pathname;
+        if(!url.match(/worksheets/)) {
+            url +=  "worksheets/" + selSheetId;
+        } else {
+            var urlMatch = url.match(/(^.*worksheets\/)\d+/);
+            url = urlMatch[1]+selSheetId;
+        }
+        history.replaceState({},window.document.title,url);
+    });
+
     // tabs interaction on dropdown selected
     var tabsList = $('#worksheets-tabs a[data-toggle="tab"]');
 

--- a/workbooks/views.py
+++ b/workbooks/views.py
@@ -236,7 +236,7 @@ def worksheet_display(request, workbook_id=0, worksheet_id=0):
     is_shareable = workbook_model.is_shareable(request)
 
     for worksheet in workbook_model.worksheets:
-        if str(worksheet.id) == worksheet_id :
+        if str(worksheet.id) == worksheet_id:
             display_worksheet = worksheet
 
     plot_types = Analysis.get_types()


### PR DESCRIPTION
Added a handler to window.beforeunload which will replace the workbook history entry with a URL which reflects the selected sheet.