### PR TITLE
Enh 1211

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-Copyright 2015, Institute for Systems Biology
+Copyright 2016, Institute for Systems Biology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ limitations under the License.
 
 import os
 import sys
-from google.appengine.ext import testbed
 
 if __name__ == "__main__":
     os.environ.setdefault("SETTINGS_VERSION", "prod")
@@ -32,6 +31,8 @@ if __name__ == "__main__":
     # See here for information on the stubs which can be initialized:
     # https://cloud.google.com/appengine/docs/python/tools/localunittesting#Python_Introducing_the_Python_testing_utilities
     if 'migrate' in sys.argv:
+        from google.appengine.ext import testbed
+
         stubBuilder = testbed.Testbed()
         stubBuilder.activate()
         stubBuilder.init_memcache_stub()

--- a/manage.py
+++ b/manage.py
@@ -19,11 +19,25 @@ limitations under the License.
 
 import os
 import sys
+from google.appengine.ext import testbed
 
 if __name__ == "__main__":
     os.environ.setdefault("SETTINGS_VERSION", "prod")
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "GenespotRE.settings")
+    stubBuilder = None
+
+    # Migration will trigger system checks, which will in turn load the views.py files. Some of these import
+    # google_appengine modules, which is a problem since the services won't be available. We make stub services to
+    # address this. So far only memcache has been needed, but there may be others in the future.
+    # See here for information on the stubs which can be initialized:
+    # https://cloud.google.com/appengine/docs/python/tools/localunittesting#Python_Introducing_the_Python_testing_utilities
+    if 'migrate' in sys.argv:
+        stubBuilder = testbed.Testbed()
+        stubBuilder.activate()
+        stubBuilder.init_memcache_stub()
 
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)
+
+    stubBuilder and stubBuilder.deactivate()


### PR DESCRIPTION
- Added a stub initialization of memcache to manage.py when migration is run. The import for the appengine testbed will only be run during migration (at which point the google.appengine library should be available). 

- Note that we'll get this (new) warning but it appears to be one we can ignore, since this is during system check and not during deployment: 
  WARNING:root:No ssl package found. urlfetch will not be able to validate SSL certificates.