### PR TITLE
Gene List Entries no longer editable

### DIFF
--- a/static/js/genes/genes.js
+++ b/static/js/genes/genes.js
@@ -111,7 +111,10 @@ require([
             if ($('div.token.invalid.repeat').length < 1) {
                 $('.helper-text__repeat').hide();
             }
-        })
+        }).on('tokenfield:edittoken',function(e){
+            e.preventDefault();
+            return false;
+        });
     }
     createTokenizer();
 


### PR DESCRIPTION
Gene entries can no longer have their text edited; they can still be removed and new ones can be added