### PR TITLE
enh 1297 - upgraded

### DIFF
--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -258,15 +258,13 @@
                     <span class="rev-history">Revision History:</span>
                     <ul>
                         {% for item in cohort.get_revision_history %}
-                            {%  if 'Applied Filters.' in item %}
-                                 {% for filters in cohort.get_filter_history %}
-                                     <li class="applied-filters">
-                                        Applied Filters:
-                                         {%  for filter in filters %}
-                                            <span>{{ filter }}</span>
-                                         {% endfor %}
-                                    </li>
-                                 {%  endfor %}
+                            {%  if 'type' in item and item.type == 'filter' %}
+                                 <li class="applied-filters">
+                                    Applied Filters:
+                                     {% for filter in item.vals %}
+                                        <span>{{ filter }}</span>
+                                     {% endfor %}
+                                </li>
                             {%  else %}
                                 <li>{{ item }}</li>
                             {%  endif %}


### PR DESCRIPTION
- Fixed a bug to displaying revision histories for complementary sets
- Filters will now display ordered among other historical operations