### PR TITLE
Bug 1416

### DIFF
--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -67,7 +67,7 @@ require([
 ], function ($, jqueryui, bootstrap, session_security, d3, d3tip, search_helpers) {
 
     var savingComment = false;
-
+    var savingChanges = false;
     var SUBSEQUENT_DELAY = 600;
     var update_displays_thread = null;
 
@@ -219,8 +219,17 @@ require([
         $('#edit-cohort-menu').hide();
     });
 
-    $('#create-cohort-form, #apply-filters-form').on('submit', function() {
+    $('#create-cohort-form, #apply-filters-form').on('submit', function(e) {
+
+        if(savingChanges) {
+            e.preventDefault();
+            return false;
+        }
+
         var form = $(this);
+
+        $('#apply-filters-form input[type="submit"]').prop('disabled',true);
+        savingChanges = true;
 
         $('.selected-filters .panel-body span').each(function() {
             var $this = $(this),
@@ -307,6 +316,7 @@ require([
             event.preventDefault();
             return false;
         }
+        $('.save-comment-btn').prop('disabled', true);
         savingComment = true;
         event.preventDefault();
         var form = this;


### PR DESCRIPTION
Once the 'save changes' button is clicked on the modal, disable the button and ignore further clicks. This should make it impossible to duplicate a cohort by clicking the Save button multiple times. Also had the comment button disable itself once it's been clicked, for the same reason.