### PR TITLE
Remove last API call out of cohorts/views

### DIFF
--- a/scripts/sproc_setup.py
+++ b/scripts/sproc_setup.py
@@ -48,187 +48,46 @@ def main():
 
     try:
 
-        metadata_counts_sproc_def = """CREATE PROCEDURE `get_filtered_counts`(
-                IN filter_statement text
-                ,IN cohort_id_in int(11)
-            )
+        raw_counts_sproc_def = """CREATE PROCEDURE `get_raw_counts`()
             BEGIN
 
-                DROP TEMPORARY TABLE IF EXISTS filtered_samples_tmp;
-
-                # Make our temporary table, filtered if a filter statement was supplied
-                SET @where_clause = '';
-                SET @and_clause = '';
-                SET @table_clause = "FROM metadata_samples ms ";
-                SET @join_clause = '';
-
-                IF NOT(cohort_id_in = '') AND NOT(cohort_id_in < 0) THEN
-                    SET @where_clause = CONCAT("cs.cohort_id = ",cohort_id_in);
-                    SET @and_clause = " AND ";
-                    SET @join_clause = 	"JOIN metadata_samples ms ON ms.SampleBarcode = cs.sample_id ";
-                    SET @table_clause = "FROM cohorts_samples cs ";
-                END IF;
-
-                IF NOT(filter_statement = '') THEN
-                    SET @where_clause = CONCAT(@where_clause,@and_clause,"(",filter_statement,")");
-                END IF;
-
-                SET @filtered_samples_tmp = CONCAT(
-                    "CREATE TEMPORARY TABLE filtered_samples_tmp AS "
-                    ,"SELECT * "
-                    ,@table_clause
-                    ,@join_clause
-                    ,"WHERE ",@where_clause
-                );
-
-                PREPARE filtered_samples FROM @filtered_samples_tmp;
-                EXECUTE filtered_samples;
-                DEALLOCATE PREPARE filtered_samples;
-
-                # Get the counts from the filtered table
-                SELECT DISTINCT gender, COUNT(1) as count FROM filtered_samples_tmp GROUP BY gender;
-                SELECT DISTINCT vital_status, COUNT(1) as count FROM filtered_samples_tmp GROUP BY vital_status;
-                SELECT DISTINCT residual_tumor, COUNT(1) as count FROM filtered_samples_tmp GROUP BY residual_tumor;
-                SELECT DISTINCT person_neoplasm_cancer_status, COUNT(1) as count FROM filtered_samples_tmp GROUP BY person_neoplasm_cancer_status;
-                SELECT DISTINCT age_at_initial_pathologic_diagnosis, COUNT(1) as count FROM filtered_samples_tmp GROUP BY age_at_initial_pathologic_diagnosis;
-                SELECT DISTINCT icd_o_3_histology, COUNT(1) as count FROM filtered_samples_tmp GROUP BY icd_o_3_histology;
-                SELECT DISTINCT has_GA_miRNASeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_GA_miRNASeq;
-                SELECT DISTINCT has_BCGSC_GA_RNASeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_BCGSC_GA_RNASeq;
-                SELECT DISTINCT histological_type, COUNT(1) as count FROM filtered_samples_tmp GROUP BY histological_type;
-                SELECT DISTINCT race, COUNT(1) as count FROM filtered_samples_tmp GROUP BY race;
-                SELECT DISTINCT has_27k, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_27k;
-                SELECT DISTINCT Project, COUNT(1) as count FROM filtered_samples_tmp GROUP BY Project;
-                SELECT DISTINCT pathologic_stage, COUNT(1) as count FROM filtered_samples_tmp GROUP BY pathologic_stage;
-                SELECT DISTINCT has_SNP6, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_SNP6;
-                SELECT DISTINCT prior_dx, COUNT(1) as count FROM filtered_samples_tmp GROUP BY prior_dx;
-                SELECT DISTINCT has_HiSeq_miRnaSeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_HiSeq_miRnaSeq;
-                SELECT DISTINCT has_UNC_HiSeq_RNASeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_UNC_HiSeq_RNASeq;
-                SELECT DISTINCT Study, COUNT(1) as count FROM filtered_samples_tmp GROUP BY Study;
-                SELECT DISTINCT tumor_type, COUNT(1) as count FROM filtered_samples_tmp GROUP BY tumor_type;
-                SELECT DISTINCT icd_o_3_site, COUNT(1) as count FROM filtered_samples_tmp GROUP BY icd_o_3_site;
-                SELECT DISTINCT tobacco_smoking_history, COUNT(1) as count FROM filtered_samples_tmp GROUP BY tobacco_smoking_history;
-                SELECT DISTINCT has_RPPA, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_RPPA;
-                SELECT DISTINCT icd_10, COUNT(1) as count FROM filtered_samples_tmp GROUP BY icd_10;
-                SELECT DISTINCT tumor_tissue_site, COUNT(1) as count FROM filtered_samples_tmp GROUP BY tumor_tissue_site;
-                SELECT DISTINCT ethnicity, COUNT(1) as count FROM filtered_samples_tmp GROUP BY ethnicity;
-                SELECT DISTINCT has_Illumina_DNASeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_Illumina_DNASeq;
-                SELECT DISTINCT neoplasm_histologic_grade, COUNT(1) as count FROM filtered_samples_tmp GROUP BY neoplasm_histologic_grade;
-                SELECT DISTINCT country, COUNT(1) as count FROM filtered_samples_tmp GROUP BY country;
-                SELECT DISTINCT has_BCGSC_HiSeq_RNASeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_BCGSC_HiSeq_RNASeq;
-                SELECT DISTINCT has_UNC_GA_RNASeq, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_UNC_GA_RNASeq;
-                SELECT DISTINCT new_tumor_event_after_initial_treatment, COUNT(1) as count FROM filtered_samples_tmp GROUP BY new_tumor_event_after_initial_treatment;
-                SELECT DISTINCT has_450k, COUNT(1) as count FROM filtered_samples_tmp GROUP BY has_450k;
-                SELECT DISTINCT SampleTypeCode, COUNT(1) as count FROM filtered_samples_tmp GROUP BY SampleTypeCode;
-
-                # Drop the temporary table
-                DROP TEMPORARY TABLE IF EXISTS filtered_samples_tmp;
+                SELECT DISTINCT gender, COUNT(1) as gender_count FROM metadata_samples GROUP BY gender;
+                SELECT DISTINCT vital_status, COUNT(1) as count FROM metadata_samples GROUP BY vital_status;
+                SELECT DISTINCT residual_tumor, COUNT(1) as count FROM metadata_samples GROUP BY residual_tumor;
+                SELECT DISTINCT person_neoplasm_cancer_status, COUNT(1) as count FROM metadata_samples GROUP BY person_neoplasm_cancer_status;
+                SELECT DISTINCT age_at_initial_pathologic_diagnosis, COUNT(1) as count FROM metadata_samples GROUP BY age_at_initial_pathologic_diagnosis;
+                SELECT DISTINCT icd_o_3_histology, COUNT(1) as count FROM metadata_samples GROUP BY icd_o_3_histology;
+                SELECT DISTINCT has_GA_miRNASeq, COUNT(1) as count FROM metadata_samples GROUP BY has_GA_miRNASeq;
+                SELECT DISTINCT has_BCGSC_GA_RNASeq, COUNT(1) as count FROM metadata_samples GROUP BY has_BCGSC_GA_RNASeq;
+                SELECT DISTINCT histological_type, COUNT(1) as count FROM metadata_samples GROUP BY histological_type;
+                SELECT DISTINCT race, COUNT(1) as count FROM metadata_samples GROUP BY race;
+                SELECT DISTINCT has_27k, COUNT(1) as count FROM metadata_samples GROUP BY has_27k;
+                SELECT DISTINCT Project, COUNT(1) as count FROM metadata_samples GROUP BY Project;
+                SELECT DISTINCT pathologic_stage, COUNT(1) as count FROM metadata_samples GROUP BY pathologic_stage;
+                SELECT DISTINCT has_SNP6, COUNT(1) as count FROM metadata_samples GROUP BY has_SNP6;
+                SELECT DISTINCT prior_dx, COUNT(1) as count FROM metadata_samples GROUP BY prior_dx;
+                SELECT DISTINCT has_HiSeq_miRnaSeq, COUNT(1) as count FROM metadata_samples GROUP BY has_HiSeq_miRnaSeq;
+                SELECT DISTINCT has_UNC_HiSeq_RNASeq, COUNT(1) as count FROM metadata_samples GROUP BY has_UNC_HiSeq_RNASeq;
+                SELECT DISTINCT Study, COUNT(1) as count FROM metadata_samples GROUP BY Study;
+                SELECT DISTINCT tumor_type, COUNT(1) as count FROM metadata_samples GROUP BY tumor_type;
+                SELECT DISTINCT icd_o_3_site, COUNT(1) as count FROM metadata_samples GROUP BY icd_o_3_site;
+                SELECT DISTINCT tobacco_smoking_history, COUNT(1) as count FROM metadata_samples GROUP BY tobacco_smoking_history;
+                SELECT DISTINCT has_RPPA, COUNT(1) as count FROM metadata_samples GROUP BY has_RPPA;
+                SELECT DISTINCT icd_10, COUNT(1) as count FROM metadata_samples GROUP BY icd_10;
+                SELECT DISTINCT tumor_tissue_site, COUNT(1) as count FROM metadata_samples GROUP BY tumor_tissue_site;
+                SELECT DISTINCT ethnicity, COUNT(1) as count FROM metadata_samples GROUP BY ethnicity;
+                SELECT DISTINCT has_Illumina_DNASeq, COUNT(1) as count FROM metadata_samples GROUP BY has_Illumina_DNASeq;
+                SELECT DISTINCT neoplasm_histologic_grade, COUNT(1) as count FROM metadata_samples GROUP BY neoplasm_histologic_grade;
+                SELECT DISTINCT country, COUNT(1) as count FROM metadata_samples GROUP BY country;
+                SELECT DISTINCT has_BCGSC_HiSeq_RNASeq, COUNT(1) as count FROM metadata_samples GROUP BY has_BCGSC_HiSeq_RNASeq;
+                SELECT DISTINCT has_UNC_GA_RNASeq, COUNT(1) as count FROM metadata_samples GROUP BY has_UNC_GA_RNASeq;
+                SELECT DISTINCT new_tumor_event_after_initial_treatment, COUNT(1) as count FROM metadata_samples GROUP BY new_tumor_event_after_initial_treatment;
+                SELECT DISTINCT has_450k, COUNT(1) as count FROM metadata_samples GROUP BY has_450k;
+                SELECT DISTINCT SampleTypeCode, COUNT(1) as count FROM metadata_samples GROUP BY SampleTypeCode;
 
             END"""
 
-
-        participant_count_sproc_def = """
-            CREATE PROCEDURE `get_participant_count`(
-                IN filter_statement text
-                ,IN cohort_id_in int(11)
-            )
-            BEGIN
-
-                SET @where_clause = '';
-                SET @and_clause = '';
-                SET @table_clause = "FROM metadata_samples ms ";
-                SET @join_clause = '';
-
-                IF NOT(cohort_id_in = '') AND NOT(cohort_id_in < 0) THEN
-                    SET @where_clause = CONCAT("WHERE cs.cohort_id = ",cohort_id_in);
-                    SET @and_clause = " AND ";
-                    SET @join_clause = 	"JOIN metadata_samples ms ON ms.SampleBarcode = cs.sample_id ";
-                    SET @table_clause = "FROM cohorts_samples cs ";
-                END IF;
-
-                IF NOT(filter_statement = '') THEN
-                    IF @where_clause = '' THEN
-                        SET @where_clause = "WHERE ";
-                    END IF;
-                    SET @where_clause = CONCAT(@where_clause,@and_clause,"(",filter_statement,")");
-                END IF;
-
-                SET @count_participants = CONCAT(
-                    "SELECT COUNT(DISTINCT ParticipantBarcode) AS participant_count "
-                    ,@table_clause
-                    ,@join_clause
-                    ,@where_clause
-                );
-
-                PREPARE participant_count FROM @count_participants;
-                EXECUTE participant_count;
-                DEALLOCATE PREPARE participant_count;
-
-            END"""
-
-        platforms_sproc_def = """CREATE PROCEDURE `get_platforms`(
-                IN filter_statement text
-                ,IN cohort_id_in int(11)
-            )
-            BEGIN
-
-                SET @where_clause = '';
-                SET @and_clause = '';
-                SET @table_clause = "FROM metadata_samples ms ";
-                SET @join_clause = '';
-
-                SET @platform_count_qry =
-                "SELECT IF(has_Illumina_DNASeq=1,'Yes', 'None') AS DNAseq_data,
-                    IF (has_SNP6=1, 'Genome_Wide_SNP_6', 'None') as cnvrPlatform,
-                    CASE
-                        WHEN has_BCGSC_HiSeq_RNASeq=1 and has_UNC_HiSeq_RNASeq=0 THEN 'HiSeq/BCGSC'
-                        WHEN has_BCGSC_HiSeq_RNASeq=1 and has_UNC_HiSeq_RNASeq=1 THEN 'HiSeq/BCGSC and UNC V2'
-                        WHEN has_UNC_HiSeq_RNASeq=1 and has_BCGSC_HiSeq_RNASeq=0 and has_BCGSC_GA_RNASeq=0 and has_UNC_GA_RNASeq=0 THEN 'HiSeq/UNC V2'
-                        WHEN has_UNC_HiSeq_RNASeq=1 and has_BCGSC_HiSeq_RNASeq=0 and has_BCGSC_GA_RNASeq=0 and has_UNC_GA_RNASeq=1 THEN 'GA and HiSeq/UNC V2'
-                        WHEN has_UNC_HiSeq_RNASeq=1 and has_BCGSC_HiSeq_RNASeq=0 and has_BCGSC_GA_RNASeq=1 and has_UNC_GA_RNASeq=0 THEN 'HiSeq/UNC V2 and GA/BCGSC'
-                        WHEN has_UNC_HiSeq_RNASeq=1 and has_BCGSC_HiSeq_RNASeq=1 and has_BCGSC_GA_RNASeq=0 and has_UNC_GA_RNASeq=0 THEN 'HiSeq/UNC V2 and BCGSC'
-                        WHEN has_BCGSC_GA_RNASeq=1 and has_UNC_HiSeq_RNASeq=0 THEN 'GA/BCGSC'
-                        WHEN has_UNC_GA_RNASeq=1 and has_UNC_HiSeq_RNASeq=0 THEN 'GA/UNC V2' ELSE 'None'
-                    END AS gexpPlatform,
-                    CASE
-                        WHEN has_27k=1 and has_450k=0 THEN 'HumanMethylation27'
-                        WHEN has_27k=0 and has_450k=1 THEN 'HumanMethylation450'
-                        WHEN has_27k=1 and has_450k=1 THEN '27k and 450k' ELSE 'None'
-                    END AS methPlatform,
-                    CASE
-                        WHEN has_HiSeq_miRnaSeq=1 and has_GA_miRNASeq=0 THEN 'IlluminaHiSeq_miRNASeq'
-                        WHEN has_HiSeq_miRnaSeq=0 and has_GA_miRNASeq=1 THEN 'IlluminaGA_miRNASeq'
-                        WHEN has_HiSeq_miRnaSeq=1 and has_GA_miRNASeq=1 THEN 'GA and HiSeq'	ELSE 'None'
-                    END AS mirnPlatform,
-                    IF (has_RPPA=1, 'MDA_RPPA_Core', 'None') AS rppaPlatform ";
-
-                IF NOT(cohort_id_in = '') AND NOT(cohort_id_in < 0) THEN
-                    SET @where_clause = CONCAT("cs.cohort_id = ",cohort_id_in);
-                    SET @and_clause = " AND ";
-                    SET @join_clause = 	"JOIN metadata_samples ms ON ms.SampleBarcode = cs.sample_id ";
-                    SET @table_clause = "FROM cohorts_samples cs ";
-                END IF;
-
-                IF NOT(filter_statement = '') THEN
-                    SET @where_clause = CONCAT(@where_clause,@and_clause,"(",filter_statement,")");
-                END IF;
-
-                SET @platforms = CONCAT(
-                    @platform_count_qry
-                    ,@table_clause
-                    ,@join_clause
-                    ,"WHERE ",@where_clause
-                );
-
-                PREPARE platform_counts FROM @platforms;
-                EXECUTE platform_counts;
-                DEALLOCATE PREPARE platform_counts;
-
-            END
-        """
-
-        cursor.execute(metadata_counts_sproc_def)
-        cursor.execute(participant_count_sproc_def)
-        cursor.execute(platforms_sproc_def)
+        cursor.execute(raw_counts_sproc_def)
 
     except Exception as e:
         print e

--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -350,7 +350,13 @@ require([
         $('a[href="#collapse-Project"]').trigger('click')
         $('input[type="checkbox"][data-value-name="TCGA"]').trigger('click');
     } else {
-        update_displays(true);
+        // If there's data passed in from the template, use it and drop it
+        if(metadata_counts !== null) {
+            search_helper_obj.update_counts_parsets_direct();
+            metadata_counts = null;
+        } else {
+            update_displays(true);    
+        }
     }
 
     $('#shared-with-btn').on('click', function(e){

--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -361,7 +361,6 @@ require([
 
     $('#shared-with-btn').on('click', function(e){
         var target = $(this).data('target');
-
         $(target + ' a[data-target="#shared-pane"]').tab('show');
     });
 

--- a/static/js/helpers/search_helpers.js
+++ b/static/js/helpers/search_helpers.js
@@ -290,11 +290,12 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
 
                     var $that = $(this),
                         value = $that.data('value-name'),
+                        label = $that.parent().text(),
                         new_count = '';
 
                     if (counts_by_name[attr]) {
-                        if (counts_by_name[attr].values[value]) {
-                            new_count = '(' + counts_by_name[attr].values[value] + ')';
+                        if (counts_by_name[attr].values[value] || counts_by_name[attr].values[label]) {
+                            new_count = '(' + (counts_by_name[attr].values[value] || counts_by_name[attr].values[label]) + ')';
                         }
                     }
                     if (new_count == '') {

--- a/static/js/helpers/search_helpers.js
+++ b/static/js/helpers/search_helpers.js
@@ -18,10 +18,67 @@
 
 define(['jquery', 'tree_graph', 'stack_bar_chart', 'draw_parsets'],
 function($, tree_graph, stack_bar_chart, draw_parsets) {
+    
     var tree_graph_obj = Object.create(tree_graph, {});
     var parsets_obj = Object.create(draw_parsets, {});
+
     return  {
-        
+
+        update_counts_parsets_direct: function() {
+
+            $('.clinical-trees .spinner').show();
+            $('.parallel-sets .spinner').show();
+            $('.cohort-info .total-values').hide();
+            $('.cohort-info .spinner').show();
+
+            var context = this;
+
+            attr_counts = metadata_counts['count'];
+
+            $('#total-samples').html(metadata_counts['total']);
+            $('#total-participants').html(metadata_counts['participants']);
+
+            this.update_filter_counts(attr_counts);
+            tree_graph_obj.draw_trees(attr_counts);
+
+            if (metadata_counts.hasOwnProperty('items')) {
+                var features = [
+                    'cnvrPlatform',
+                    'DNAseq_data',
+                    'methPlatform',
+                    'gexpPlatform',
+                    'mirnPlatform',
+                    'rppaPlatform'
+                ];
+
+                var plot_features = [
+                    context.get_readable_name(features[0]),
+                    context.get_readable_name(features[1]),
+                    context.get_readable_name(features[2]),
+                    context.get_readable_name(features[3]),
+                    context.get_readable_name(features[4]),
+                    context.get_readable_name(features[5])
+                ];
+                for (var i = 0; i < metadata_counts['items'].length; i++) {
+                    var new_item = {};
+                    for (var j = 0; j < features.length; j++) {
+                        var item = metadata_counts['items'][i];
+                        new_item[plot_features[j]] = context.get_readable_name(item[features[j]]);
+                    }
+                    metadata_counts['items'][i] = new_item;
+                }
+
+                parsets_obj.draw_parsets(metadata_counts, plot_features);
+            } else {
+                console.warn("No 'items' found in metadata_counts: " + metadata_counts);
+            }
+
+            $('.clinical-trees .spinner').hide();
+            $('.parallel-sets .spinner').hide();
+            $('.cohort-info .spinner').hide();
+            $('.cohort-info .total-values').show();
+        },
+
         update_counts_parsets: function(base_url_domain, endpoint, cohort_id, version){
             var context = this;
             var filters = this.format_filters();

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -475,6 +475,7 @@
     var base_url = '{{ base_url|safe }}';
     var base_api_url = '{{ base_api_url|safe }}';
     var cohort_id = {{ cohort.id }};
+    var metadata_counts = {{ metadata_counts }}
     </script>
 {% endblock %}
 

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -475,7 +475,7 @@
     var base_url = '{{ base_url|safe }}';
     var base_api_url = '{{ base_api_url|safe }}';
     var cohort_id = {{ cohort.id }};
-    var metadata_counts = {{ metadata_counts }}
+    var metadata_counts = {{ metadata_counts|tojson|safe }};
     </script>
 {% endblock %}
 


### PR DESCRIPTION
Associated with PR #13 from Common:

- Remove the remaining API call from cohorts/views/cohort_detail
- Change the attribute availability sorter to handle absence of true values (can happen on very small cohorts)
- Alter cohorts_details.js to only do a request for new metadata if no metadata was passed in from the view via the template
- Fixed some aspects of the Data Type tab on the filter panel (counts should list, filters will work but seem to be ANDing insteading of ORing)