### PR TITLE
Improvments to bug 1364

### DIFF
--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -207,6 +207,7 @@ require([
         $('#default-cohort-menu').hide();
         $('#edit-cohort-menu').show();
         showHideMoreGraphButton();
+        $('#multi-categorical').prop('scrollLeft',150);
     });
 
     $('#cancel-add-filter-btn').on('click', function() {

--- a/static/js/parallel_sets.js
+++ b/static/js/parallel_sets.js
@@ -38,6 +38,9 @@ define(['d3', 'd3parsets'], function(d3, d3parsets) {
 
             var stopPlot = new Date().getTime();
 
+            // Auto-scroll over to center the graph on any redraw
+            $('#multi-categorical').prop('scrollLeft',150);
+
             console.debug("[BENCHMARKING] Time to build parallel coords plot: "+(stopPlot-startPlot)+ "ms");
 
         }


### PR DESCRIPTION
- Automatically scroll the parallel coords plot to the left to center it when a cohort is first opened in an edit page, and any time a change is made which reloads the graph.

This is a stop-gap until we can come up with a more elegant solution.