### PR TITLE
Bug/Enh 1206

### DIFF
--- a/GenespotRE/templatetags/custom_tags.py
+++ b/GenespotRE/templatetags/custom_tags.py
@@ -83,7 +83,7 @@ ATTR_SPECIFIC_TRANSLATION = {
         'Yes, History of Synchronous and or Bilateral Malignancy': 'Yes, History of Synchronous and or Bilateral Malignancy',
         'Yes, History of Synchronous/Bilateral Malignancy': 'Yes, History of Synchronous/Bilateral Malignancy'
     },
-    'BMI': {
+    'bmi': {
         'underweight': 'Underweight: BMI less that 18.5',
         'normal weight': 'Normal weight: BMI is 18.5 - 24.9',
         'overweight': 'Overweight: BMI is 25 - 29.9',

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -225,13 +225,13 @@
 
         <div class="cohort-selected-filters panel panel-default">
             <div class="panel-heading">
-                <h4 class="panel-title">Selected Filters</h4>
+                <h4 class="panel-title">Current Filters</h4>
             </div>
             <div class="panel-body">
-                {% for filter in cohort.get_filters %}
+                {% for filter in cohort.get_current_filters %}
                     <span class="filter-label label label-default space-right-5">{{ filter.name }}: {{ filter.value }}</span>
                 {% empty %}
-                    <p>There were no filters used to create this cohort.</p>
+                    <p>No filters have been applied to this cohort.</p>
                 {% endfor %}
             </div>
         </div>
@@ -253,6 +253,16 @@
                 </div>
                 <div class="row col-md-12 space-bottom-10">
                     <span>Your Permissions: {{ cohort.perm.perm }}</span>
+                </div>
+                <div class="row col-md-12 space-bottom-10">
+                    <span>Creation Filters: </span>
+                    <span class="applied-filters">
+                     {% for filter in cohort.get_creation_filters %}
+                         <span>{{ filter.name }}: {{ filter.value }}</span>
+                     {% empty %}
+                         There were no filters used to create this cohort.
+                     {% endfor %}
+                     </span>
                 </div>
                 <div class="row col-md-12 space-bottom-10">
                     <span class="rev-history">Revision History:</span>


### PR DESCRIPTION
The cohort details page will now break out filters in the following way:

- 'Selected Filters' is now 'Current Filters', which shows the effectively-active set of filters. This means that any mutually exclusive sets will only show the most recent filter applied. (Eg., applying Study:GBM and Study:OV followed by Study:OV will list only Study:OV)
- 'Creation Filters' has been added to the Details panel, and will show the set of filters applied when the cohort was created (if there was one).

Requires PR from Common of same title