### PR TITLE
Minor bugfix and template upgrade

### DIFF
--- a/GenespotRE/templatetags/custom_tags.py
+++ b/GenespotRE/templatetags/custom_tags.py
@@ -67,34 +67,6 @@ ALPHANUM_SORT = [
 ]
 
 ATTR_SPECIFIC_TRANSLATION = {
-    'SampleTypeCode': {
-        '01': 'Primary solid Tumor',
-        '02': 'Recurrent Solid Tumor',
-        '03': 'Primary Blood Derived Cancer - Peripheral Blood',
-        '04': 'Recurrent Blood Derived Cancer - Bone Marrow',
-        '05': 'Additional - New Primary',
-        '06': 'Metastatic',
-        '07': 'Additional Metastatic',
-        '08': 'Human Tumor Original Cells',
-        '09': 'Primary Blood Derived Cancer - Bone Marrow',
-        '10': 'Blood Derived Normal',
-        '11': 'Solid Tissue Normal',
-        '12': 'Buccal Cell Normal',
-        '13': 'EBV Immortalized Normal',
-        '14': 'Bone Marrow Normal',
-        '20': 'Control Analyte',
-        '40': 'Recurrent Blood Derived Cancer - Peripheral Blood',
-        '50': 'Cell Lines',
-        '60': 'Primary Xenograft Tissue',
-        '61': 'Cell Line Derived Xenograft Tissue'
-    },
-    'prior_dx': {
-        'Yes': 'Yes',
-        'No': 'No',
-        'Yes, History of Prior Malignancy': 'Yes, History of Prior Malignancy',
-        'Yes, History of Synchronous and or Bilateral Malignancy': 'Yes, History of Synchronous and or Bilateral Malignancy',
-        'Yes, History of Synchronous/Bilateral Malignancy': 'Yes, History of Synchronous/Bilateral Malignancy'
-    },
     'bmi': {
         'underweight': 'Underweight: BMI less that 18.5',
         'normal weight': 'Normal weight: BMI is 18.5 - 24.9',
@@ -223,12 +195,12 @@ def get_readable_name(csv_name, attr=None):
         return ATTR_SPECIFIC_TRANSLATION[attr][csv_name]
     elif attr == 'Project' or attr == 'Study':
         return csv_name.upper()
-    elif TRANSLATION_DICTIONARY.get(csv_name):
+    elif TRANSLATION_DICTIONARY.get(csv_name) and attr is not 'prior_dx':
         return TRANSLATION_DICTIONARY.get(csv_name)
     else:
         csv_name = csv_name.replace('_', ' ')
         # Do not convert the Roman numerals in the stages
-        if attr is not 'pathologic_stage' and attr is not 'residual_tumor':
+        if attr is not 'pathologic_stage' and attr is not 'residual_tumor' and attr is not 'prior_dx':
             csv_name = string.capwords(csv_name)
         csv_name = csv_name.replace(' To ', ' to ')
         return csv_name

--- a/static/js/visualizations/createTreeGraph.js
+++ b/static/js/visualizations/createTreeGraph.js
@@ -19,13 +19,6 @@
 define(['jquery', 'd3', 'd3tip', 'vis_helpers'],
 function($, d3, d3tip, vis_helpers) {
 
-    // Note this is relying on the checkbox menu flyout, which is present in the cohorts DOM but
-    // not visible sometimes. If this flyout is ever edited this code must be edited to reflect that
-    var getSampleTypeName = function(sampleTypeCode) {
-        var label = $("#SampleTypeCode input[data-value-name='" + sampleTypeCode + "']").parent()[0].innerHTML;
-        return label.substring(label.indexOf(">")+1);
-    };
-
     var CURSOR_TOOLTIP_PAD = 20;
 
     // If you want to override the tip coming in from the create call,
@@ -42,15 +35,14 @@ function($, d3, d3tip, vis_helpers) {
                 treeTip.offset([CURSOR_TOOLTIP_PAD, 0]);
             }
 
-            var display =  (d.parent.name === "SampleTypeCode") ? getSampleTypeName(d.name) : d.name;
-            return '<span>' + display + ': ' + d.count + '</span>';
+            return '<span>' + d.name + ': ' + d.count + '</span>';
         });
 
     return {
         get_treemap_ready: function(data, attribute) {
             var children = [];
             for (var i in data) {
-                children.push({name:data[i]['value'].replace(/_/g, ' '), count: data[i]['count']});
+                children.push({name:(data[i]['displ_name'] || data[i]['value'].replace(/_/g, ' ')), count: data[i]['count']});
             }
             return {children: children, name: attribute};
         },
@@ -112,7 +104,7 @@ function($, d3, d3tip, vis_helpers) {
             var clin_attr = [
                 'Study',
                 'vital_status',
-                'SampleTypeCode',  //todo: make readable names out of numeric codes
+                'SampleTypeCode',
                 'tumor_tissue_site',
                 'gender',
                 'age_at_initial_pathologic_diagnosis'

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -109,7 +109,7 @@
                                                         <li class="checkbox">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}" data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
-                                                                {% if v.value == 'None' %}NA{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
+                                                                {% if v.value == 'None' %}NA{% elif 'displ_name' in v %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                 <span class="count">({{ v.count }})</span>
                                                             </label>
                                                         </li>
@@ -118,7 +118,7 @@
                                                         <li class="extra-values checkbox" style="display:none;">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}" data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
-                                                                {% if v.value == 'None' %}NA{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
+                                                                {% if v.value == 'None' %}NA{% elif 'displ_name' in v %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                 <span class="count">({{ v.count }})</span>
                                                             </label>
                                                         </li>
@@ -126,7 +126,7 @@
                                                         <li class="extra-values checkbox" style="display:none;">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}" data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
-                                                                {% if v.value == 'None' %}NA{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
+                                                                {% if v.value == 'None' %}NA{% elif 'displ_name' in v %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                 <span class="count">({{ v.count }})</span>
                                                             </label>
                                                         </li>

--- a/templates/cohorts/new_cohort.html
+++ b/templates/cohorts/new_cohort.html
@@ -80,7 +80,7 @@
                                                         <li class="checkbox">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}" data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
-                                                                {% if v.value == 'None' %}NA{% else %}{{v.value|get_readable_name:attr }}{% endif %}
+                                                                {% if v.value == 'None' %}NA{% elif 'displ_name' in v %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                 <span class="count">({{ v.count }})</span>
                                                             </label>
                                                         </li>
@@ -89,7 +89,7 @@
                                                         <li class="extra-values checkbox" style="display:none;">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}" data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
-                                                                {% if v.value == 'None' %}NA{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
+                                                                {% if v.value == 'None' %}NA{% elif 'displ_name' in v %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                 <span class="count">({{ v.count }})</span>
                                                             </label>
                                                         </li>
@@ -97,7 +97,7 @@
                                                         <li class="extra-values checkbox" style="display:none;">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}" data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
-                                                                {% if v.value == 'None' %}NA{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
+                                                                {% if v.value == 'None' %}NA{% elif 'displ_name' in v %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                 <span class="count">({{ v.count }})</span>
                                                             </label>
                                                         </li>
@@ -130,8 +130,10 @@
                                             {% for v in attr_list_count|get_named_item:attr|get_item:'values' %}
                                                 <li class="checkbox">
                                                     <!-- todo: make a custom tag for the id for data_attr attributes-->
-                                                    <label><input type="checkbox" name="elements-selected" data-value-name="{{ v.value|get_data_attr_id:attr }}" >{{ v.value }}</label>
-                                                    <span class="count">({{ v.count }})</span>
+                                                    <label>
+                                                        <input type="checkbox" name="elements-selected" data-value-name="{{ v.value|get_data_attr_id:attr }}" >{{ v.value }}
+                                                        <span class="count">({{ v.count }})</span>
+                                                    </label>
                                                 </li>
                                             {% endfor %}
                                         {% endif %}


### PR DESCRIPTION
- Move SampleTypeCode data dictionary into cohorts/views, removed prior_dx (wasn't actually doing anything) and corrected the bug it was meant to fix
- Cohorts new and detail templates now check for 'displ_name' before defaulting to 'value' for the display of filters; allows for display-specific names to come from the view instead of being stored in custom_tags
- Fixed treeGraph bug where SampleTypeCode count was displaying twice

Requires accompanying PR from Common