### PR TITLE
Bug 1464 + preprep for 1423

### DIFF
--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -172,45 +172,6 @@
                         {% endfor %}
                     </ul>
                 </div>
-{#                <!-- molecular filters tab -->#}
-{#                <div role="tabpanel" class="tab-pane" id="molecular-filters">#}
-{#                    <div class="panel-group" id="molecular-accordion" role="tablist" aria-multiselectable="true">#}
-{#                        {% for attr in molec_attr %}#}
-{#                            <div class="panel panel-default">#}
-{#                                <a role="button" data-toggle="collapse" data-parent="#clin-accordion" href="#collapse-{{ attr }}" aria-expanded="true" aria-controls="collapse-{{ attr }}">#}
-{#                                    <div class="panel-heading" role="tab" id="heading-{{ attr }}"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down" style="display:none;"></i> {{ attr|get_readable_name }}</div>#}
-{#                                </a>#}
-{#                                <div id="collapse-{{ attr }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ attr }}">#}
-{#                                    <div class="panel-body">#}
-{#                                        <ul class="search-checkbox-list" id="{{ attr }}">#}
-{#                                            <form action="" method="GET" class="form-horizontal" id="{{ attr }}-form">#}
-{#                                                <div class="form-group">#}
-{#                                                    <div class="col-sm-3"><label for="{{ attr }}-genes" class="control-label">Gene:</label></div>#}
-{#                                                    <div class="col-md-5">#}
-{#                                                        <input class="form-control" type="text" id="{{ attr }}-genes" name="gene">#}
-{#                                                    </div>#}
-{##}
-{#                                                </div>#}
-{#                                                {% if attr == 'mRNA_expression' %}#}
-{#                                                <ul>#}
-{#                                                    <li>#}
-{#                                                    <!--<input type="checkbox" name="RPKM" id="RPKM-check">-->#}
-{#                                                    <label for="RPKM-check">RPKM</label>#}
-{#                                                    </li>#}
-{#                                                    <li>#}
-{#                                                    <!--<input type="checkbox" name="normalized_count" id="normalized_count-check">-->#}
-{#                                                    <label for="normalized_count-check">normalized count</label>#}
-{#                                                    </li>#}
-{#                                                </ul>#}
-{#                                                {% endif %}#}
-{#                                            </form>#}
-{#                                        </ul>#}
-{#                                    </div>#}
-{#                                </div>#}
-{#                            </div>#}
-{#                        {% endfor %}#}
-{#                    </div>#}
-{#                </div>#}
             </div>
         </div>
     </div>

--- a/templates/share/site_header.html
+++ b/templates/share/site_header.html
@@ -10,7 +10,13 @@
             <div class="col-lg-12">
             <div class="nav navbar-left">
                  <ul class="">
-                     <li class="navbar-item"> <a href="{% url 'landing_page' %}"><img class="navbar-brand" src="{% static 'img/isblogo.png' %}" alt="ISB Logo"/><span class="navbar-item">ISB-CGC</span></a></li>
+                    <li class="navbar-item">
+                        {% if user.is_authenticated %}
+                             <a href="{% url 'dashboard' %}" title="Dashboard" >
+                        {%  else %}
+                            <a href="{% url 'landing_page' %}" title="Home Page" >
+                        {%  endif %}
+                        <img class="navbar-brand" src="{% static 'img/isblogo.png' %}" alt="ISB Logo"/><span class="navbar-item">ISB-CGC</span></a></li>
                      <li class="navbar-link navbar-item"><a href="{% url 'landing_page' %}">About Us</a></li>
                      <li class="navbar-link navbar-item">
                          <a href="http://isb-cancer-genomics-cloud.readthedocs.org/en/latest/" target="_blank">Documentation</a>


### PR DESCRIPTION
- Removed unused template block from cohort_details
- Reverted upper-left logo target to dashboard when authenticated and home page when not, added title text indicating target