### PR TITLE
Bug 1466

### DIFF
--- a/static/js/helpers/search_helpers.js
+++ b/static/js/helpers/search_helpers.js
@@ -67,7 +67,7 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
                     }
                 }
             }
-            return attr_counts_clin_trees;
+            return (attr_counts_clin_trees || attr_counts);
         },
 
         update_counts_parsets_direct: function(filters) {


### PR DESCRIPTION
- Fixing a JS error which was causing loading of the clinical trees on the new cohorts page to fail.