### PR TITLE
Bug 1486

### DIFF
--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -161,7 +161,7 @@
                                                     <!-- todo: make a custom tag for the id for data_attr attributes-->
                                                     <label>
                                                         <input type="checkbox" name="elements-selected" data-value-name="{{ v.value|get_data_attr_id:attr }}" data-displ-name="{{  v.value }}">
-                                                        {{ v.value }} <span class="count">({{ v.count }})</span>
+                                                        {% if v.value == 'None' %}NA{% else %}{{ v.value }}{% endif %} <span class="count">({{ v.count }})</span>
                                                     </label>
                                                 </li>
                                             {% endfor %}

--- a/templates/cohorts/new_cohort.html
+++ b/templates/cohorts/new_cohort.html
@@ -131,8 +131,8 @@
                                                 <li class="checkbox">
                                                     <!-- todo: make a custom tag for the id for data_attr attributes-->
                                                     <label>
-                                                        <input type="checkbox" name="elements-selected" data-value-name="{{ v.value|get_data_attr_id:attr }}" data-displ-name="{{  v.value }}">
-                                                        {{ v.value }} <span class="count">({{ v.count }})</span>
+                                                        <input type="checkbox" name="elements-selected" data-value-name="{{ v.value|get_data_attr_id:attr }}" data-displ-name="{{ v.value }}">
+                                                         {% if v.value == 'None' %}NA{% else %}{{ v.value }}{% endif %} <span class="count">({{ v.count }})</span>
                                                     </label>
                                                 </li>
                                             {% endfor %}


### PR DESCRIPTION
Per the issues with #1486/#1444, the Data filter tab will now behave the same was as the Donor tab with regard to NULL database entries (they'll display as 'NA' rather than being lumped in with 'False').