### PR TITLE
Small fix to single-cohort unsharing

### DIFF
--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -679,7 +679,7 @@ require([
             type        :'POST',
             url         : url,
             dataType    :'json',
-            data        : {owner: true, user_id: user_id},
+            data        : {user_id: user_id},
             beforeSend  : function(xhr){xhr.setRequestHeader("X-CSRFToken", csrftoken);},
             success : function (data) {
                 button.parents('tr').remove();


### PR DESCRIPTION
- Since the unshare_cohort view now handles all ownership checking, there's no need to send this in the request (and it's more secure to not do so)