### PR TITLE
Enh 1328

### DIFF
--- a/static/js/helpers/vis_helpers.js
+++ b/static/js/helpers/vis_helpers.js
@@ -20,16 +20,22 @@ define(['jquery'], function($) {
     var base_feature_search_url = base_api_url + '/_ah/api/feature_type_api/v1/feature_search?';
     var feature_search_url = base_feature_search_url;
     return {
+        isValidNumber: function(val) {
+            return (
+                val !== null && val !== undefined && (typeof(val) !== "string" ||
+                (val.match(/[^\d+,\.]/g) == null)
+            ));
+        },
         get_min_max: function(data, selector) {
+            var self=this;
             return [Math.floor(d3.min(data, function(d) {
-                if (d[selector] && d[selector] != "NA") {
+                if (self.isValidNumber(d[selector])) {
                     return parseFloat(d[selector]);
                 } else {
                     return 0
                 }
-            })),
-                    Math.ceil(d3.max(data, function(d) {
-                if (d[selector] && d[selector] != "NA") {
+            })), Math.ceil(d3.max(data, function(d) {
+                if (self.isValidNumber(d[selector])) {
                     return parseFloat(d[selector]);
                 } else {
                     return 0
@@ -39,7 +45,7 @@ define(['jquery'], function($) {
         values_only: function(data, attr) {
             var result = [];
             for (var i = 0; i < data.length; i++ ) {
-                if (data[i][attr] && data[i][attr] != 'None') {
+                if (data[i][attr] !== null && data[i][attr] !== undefined && data[i][attr] != "None" && data[i][attr] !== "NA") {
                     result.push(data[i][attr]);
                 }
             }

--- a/static/js/helpers/vis_helpers.js
+++ b/static/js/helpers/vis_helpers.js
@@ -17,62 +17,29 @@
  */
 
 define(['jquery'], function($) {
-
     var base_feature_search_url = base_api_url + '/_ah/api/feature_type_api/v1/feature_search?';
     var feature_search_url = base_feature_search_url;
     return {
-        isValidNumber: function(n) {
-            return (
-                n !== undefined && n !== null && (typeof(n) !== "string" || n.match(/[^\d,\.]/g) === null)
-            );
-        },
-        LOG_SCALE: {
-            NO_LOG_SCALE: 0,
-            X_LOG_SCALE: 1,
-            Y_LOG_SCALE: 2,
-            BOTH_LOG_SCALE: 3,
-            isScaleX: function(logScale) {
-                return (logScale && (logScale === this.BOTH_LOG_SCALE || logScale === this.X_LOG_SCALE));
-            },
-            isScaleY: function(logScale) {
-                return (logScale && (logScale === this.BOTH_LOG_SCALE || logScale === this.Y_LOG_SCALE));
-            }
-        },
-        get_min_max: function(data, selector, logScale) {
-            var self=this;
-            var filtered_data = data;
-            if(logScale) {
-                filtered_data = data.filter(function(obj){
-                    return (self.isValidNumber(obj[selector]) && parseFloat(obj[selector]) !== 0);
-                });
-            }
-
-            var min = d3.min(filtered_data, function(d) {
-                if (self.isValidNumber(d[selector])) {
+        get_min_max: function(data, selector) {
+            return [Math.floor(d3.min(data, function(d) {
+                if (d[selector] && d[selector] != "NA") {
                     return parseFloat(d[selector]);
                 } else {
                     return 0
                 }
-            }), max = d3.max(filtered_data, function(d) {
-                if (self.isValidNumber(d[selector])) {
+            })),
+                    Math.ceil(d3.max(data, function(d) {
+                if (d[selector] && d[selector] != "NA") {
                     return parseFloat(d[selector]);
                 } else {
                     return 0
                 }
-            });
-
-            if(filtered_data.length <= 0) {
-                // TODO: alert on 'no valid values in this selector' ?
-                min = 0;
-                max = 0;
-            }
-
-            return [(logScale ? parseFloat(min.toFixed(3)) : Math.floor(min)),Math.ceil(max)];
+            }))];
         },
         values_only: function(data, attr) {
             var result = [];
             for (var i = 0; i < data.length; i++ ) {
-                if (this.isValidNumber(data[i][attr])) {
+                if (data[i][attr] && data[i][attr] != 'None') {
                     result.push(data[i][attr]);
                 }
             }

--- a/static/js/visualizations/createHistogram.js
+++ b/static/js/visualizations/createHistogram.js
@@ -36,7 +36,7 @@ function($, d3, d3tip, helpers) {
     var histoTip = null;
 
     return {
-        createHistogramPlot : function (svg_param, raw_Data, values_only, width_param, height_param, x_attr, xLabel, tip, margin_param, logScale) {
+        createHistogramPlot : function (svg_param, raw_Data, values_only, width_param, height_param, x_attr, xLabel, tip, margin_param, legend) {
 
             tip = histoTip || tip;
 
@@ -50,34 +50,14 @@ function($, d3, d3tip, helpers) {
                 .bins(num_bins)
                 .frequency(false)(values_only);
             var kde = science.stats.kde().sample(values_only);
-            var tmp = helpers.get_min_max(raw_Data, x_attr, helpers.LOG_SCALE.isScaleX(logScale));
+            var tmp = helpers.get_min_max(raw_Data, x_attr);
             min_n = tmp[0];
             max_n = tmp[1];
 
-            if(logScale && (min_n == 0 || (max_n > 0 && min_n < 0))) {
-                // we don't currently support log scales crossing 0 or containing only 0 as a min,
-                // so recalculate min and max with 0s included and fall back to linear
-                $('#log-scale-alert').show();
-                $('#x-log-scale').prop('checked',false);
-                logScale = null;
-                tmp = helpers.get_min_max(raw_Data, x_attr, false);
-                min_n = tmp[0];
-                max_n = tmp[1];
-            } else {
-                $('#log-scale-alert').hide();
-            }
 
-            if(helpers.LOG_SCALE.isScaleX(logScale)) {
-                x = d3.scale.log()
-                    .clamp(true)
-                    .range([margin.left, width - margin.right])
-                    .domain([min_n, max_n]);
-            } else {
-                x = d3.scale.linear()
-                    .range([margin.left, width - margin.right])
-                    .domain([min_n, max_n]);
-            }
-
+            x = d3.scale.linear()
+                .range([margin.left, width - margin.right])
+                .domain([min_n, max_n]);
             xAxis = d3.svg.axis()
                 .scale(x)
                 .orient('bottom');

--- a/static/js/visualizations/createScatterPlot.js
+++ b/static/js/visualizations/createScatterPlot.js
@@ -20,40 +20,26 @@ define (['jquery', 'd3', 'vizhelpers'],
 function($, d3, vizhelpers) {
     var helpers = Object.create(vizhelpers, {});
     return {
-        create_scatterplot: function(svg, data, domain, range, xLabel, yLabel, xParam, yParam, colorBy, legend, width, height, cohort_set, logScale) {
-
+        create_scatterplot: function(svg, data, domain, range, xLabel, yLabel, xParam, yParam, colorBy, legend, width, height, cohort_set) {
             var margin = {top: 10, bottom: 50, left: 50, right: 10};
             var yVal = function(d) {
-                if (helpers.isValidNumber(d[yParam])){
-                    return d[yParam];
-                } else {
-                    d[yParam] = range[1];
-                    return range[1];
-                }
-            };
-            
-            var yScale = null;
-            if(helpers.LOG_SCALE.isScaleY(logScale)) {
-                yScale = d3.scale.log().clamp(true).range([height-margin.bottom, margin.top]).domain(range);
-            } else {
-                yScale = d3.scale.linear().range([height-margin.bottom, margin.top]).domain(range);
-            }
+                    if (d[yParam] && d[yParam] != 'NA') {
+                        return d[yParam];
+                    } else {
+                        d[yParam] = range[1];
+                        return range[1];
+                    }
+                };
 
-            var yMap = function(d) {
-                if(helpers.isValidNumber(d.y)){
-                    return yScale(yVal(d));
-                } else {
-                    return 0;
-                }
-            };
-
+            var yScale = d3.scale.linear().range([height-margin.bottom, margin.top]).domain(range);
+            var yMap = function(d) { if(typeof(Number(d.y)) == "number"){return yScale(yVal(d));} else { return 0;}};
             var yAxis = d3.svg.axis()
                     .scale(yScale)
                     .orient("left")
                     .tickSize(-width - margin.left - margin.right, 0, 0);
 
             var xVal = function(d) {
-                    if (helpers.isValidNumber(d[xParam])) {
+                    if (d[xParam] && d[xParam] != 'NA') {
                         return d[xParam];
                     } else {
                         d[xParam] = domain[1];
@@ -61,14 +47,8 @@ function($, d3, vizhelpers) {
                     }
                 };
 
-            var xScale = null;
-            if(helpers.LOG_SCALE.isScaleX(logScale)) {
-                xScale = d3.scale.log().clamp(true).range([margin.left, width]).domain(domain);
-            } else {
-                xScale = d3.scale.linear().range([margin.left, width]).domain(domain);
-            }
-
-            var xMap = function(d) {if(helpers.isValidNumber(d.x)){return xScale(xVal(d));} else { return 0;}};
+            var xScale = d3.scale.linear().range([margin.left, width]).domain(domain);
+            var xMap = function(d) {if(typeof(Number(d.x)) == "number"){return xScale(xVal(d));} else { return 0;}};
             var xAxis = d3.svg.axis()
                     .scale(xScale)
                     .orient("bottom")

--- a/static/js/visualizations/createViolinPlot.js
+++ b/static/js/visualizations/createViolinPlot.js
@@ -62,14 +62,12 @@ function($, d3, vizhelpers) {
                 .attr('transform', 'rotate(90, 0, 0) scale(1, -1)');
         },
         addPoints: function (svg, raw_data, values_only, height, width, violin_width, domain, range, xdomain, xAttr, yAttr, colorBy, legend, margin, cohort_set) {
-            // for each key, value_list in values_only
-                // create a histogram and new dictionary where key=plot_number and value=histogram_values
 
             // remove counts from xdomain
             var tmp = xdomain;
             xdomain = [];
             for (var i = 0; i < tmp.length; i++) {
-                xdomain.push(tmp[i].split(':')[0]);
+                xdomain.push(tmp[i].split(/:\d+/)[0]);
             }
 
             // Somehow use the histogram values to determine the x position of the dot
@@ -96,10 +94,16 @@ function($, d3, vizhelpers) {
                     .frequency(0)(values_only[key].sort(d3.descending));
             }
 
+            var nonNullData = [];
 
+            raw_data.map(function(d){
+                if(helpers.isValidNumber(d.y)) {
+                    nonNullData.push(d);
+                }
+            });
 
             svg.selectAll('.dot')
-                .data(raw_data)
+                .data(nonNullData)
                 .enter().append('circle')
                 .attr('id', function(d) { return d['sample_id']; })
                 .attr('class', function(d) { return d[colorBy]; })
@@ -128,8 +132,6 @@ function($, d3, vizhelpers) {
                     return y(d[yAttr]);
                 })
                 .attr('r', 2);
-
-
 
             legend = legend.attr('height', 20 * color.domain().length + 30);
             legend.append('text')
@@ -170,6 +172,7 @@ function($, d3, vizhelpers) {
         },
         addMedianLine: function(svg, raw_data, values_only, height, width, domain, range) {
             var median = d3.median(values_only);
+
             var y = d3.scale.linear()
                 .range(range)
                 .domain(domain);
@@ -187,7 +190,6 @@ function($, d3, vizhelpers) {
                 .attr('d', line)
                 .style('stroke', 'green')
                 .style('fill', 'none')
-
         },
         createViolinPlot: function(svg, raw_Data, height, violin_width, max_y, min_y, xLabel, yLabel, xAttr, yAttr, colorBy, legend, cohort_set) {
             var margin = {top: 0, bottom: 50, left: 50, right: 0};
@@ -259,8 +261,10 @@ function($, d3, vizhelpers) {
 
                 }
 
-                this.addViolin(g, processed_data[key], values_only, height, violin_width, domain, range);
-                this.addMedianLine(g, processed_data[key], values_only, height, violin_width, domain, range);
+                if(values_only.length > 0) {
+                    this.addViolin(g, processed_data[key], values_only, height, violin_width, domain, range);
+                    this.addMedianLine(g, processed_data[key], values_only, height, violin_width, domain, range);
+                }
                 i += 1;
             }
 

--- a/static/js/visualizations/plotFactory.js
+++ b/static/js/visualizations/plotFactory.js
@@ -87,7 +87,7 @@ define([
     /*
         Generate Histogram
      */
-    function generate_histogram(margin, plot_selector, height, width, x_attr, data, logScale, scale_type){
+    function generate_histogram(margin, plot_selector, height, width, x_attr, data){
         var svg = d3.select(plot_selector)
                 .append('svg')
                 .attr('width', width + 10)
@@ -103,9 +103,7 @@ define([
                 'x',
                 generate_axis_label(x_attr),
                 cubby_tip,
-                margin,
-                logScale,
-                scale_type);
+                margin);
 
         return  {plot : plot, svg : svg}
     }
@@ -113,43 +111,11 @@ define([
     /*
         Generate scatter plot
     */
-    function generate_scatter_plot(margin, plot_selector, legend_selector, height, width, x_attr, y_attr, color_by, cohort_set, data, logScale) {
+    function generate_scatter_plot(margin, plot_selector, legend_selector, height, width, x_attr, y_attr, color_by, cohort_set, data) {
+         var domain = helpers.get_min_max(data, 'x');
+         var range = helpers.get_min_max(data, 'y');
 
-        var domain = helpers.get_min_max(data, 'x', helpers.LOG_SCALE.isScaleX(logScale));
-        var range = helpers.get_min_max(data, 'y', helpers.LOG_SCALE.isScaleY(logScale));
-
-        $('#log-scale-alert').hide();
-
-        if(helpers.LOG_SCALE.isScaleY(logScale) && (range[0] == 0 || (range[0] < 0 && range[1] > 0))) {
-            // we don't currently support log scales crossing 0 or containing only 0,
-            // so we recalculate min and max with 0s included and fall back to linear
-            $('#log-scale-alert').show();
-            $('#y-log-scale').prop('checked',false);
-            // This might be a 'both' log scale, if so convert to just X
-            if(helpers.LOG_SCALE.isScaleX(logScale)) {
-                logScale = helpers.LOG_SCALE.X_LOG_SCALE;
-            } else {
-                logScale = null;
-            }
-            range = helpers.get_min_max(data, 'y', false);
-        }
-
-        if(helpers.LOG_SCALE.isScaleX(logScale) && (domain[0] == 0 || (domain[0] < 0 && domain[1] > 0))) {
-            // we don't currently support log scales crossing 0
-            // recalculate min and max with 0s included and
-            // fall back to linear
-            $('#log-scale-alert').show();
-            $('#x-log-scale').prop('checked',false);
-            // This might be a 'both' log scale; if so convert to just Y
-            if(helpers.LOG_SCALE.isScaleY(logScale)) {
-                logScale = helpers.LOG_SCALE.Y_LOG_SCALE;
-            } else {
-                logScale = null;
-            }
-            domain = helpers.get_min_max(data, 'x', false);
-        }
-
-        var legend = d3.select(legend_selector)
+         var legend = d3.select(legend_selector)
              .append('svg')
              .attr('width', width);
          var svg = d3.select(plot_selector)
@@ -168,8 +134,7 @@ define([
              legend,
              width,
              height,
-             cohort_set,
-             logScale
+             cohort_set
          );
 
          return  {plot : plot, svg : svg}
@@ -178,24 +143,11 @@ define([
     /*
         Generate violin plot
      */
-    function generate_violin_plot(margin, plot_selector, legend_selector, height, width, x_attr, y_attr, color_by, cohort_set, data, logScale) {
+    function generate_violin_plot(margin, plot_selector, legend_selector, height, width, x_attr, y_attr, color_by, cohort_set, data) {
         var violin_width = 200;
-        var tmp = helpers.get_min_max(data, 'y', logScale);
-
-        if(logScale && (tmp[0] == 0 || (tmp[1] > 0 && tmp[0] < 0))) {
-            // we don't currently support log scales crossing 0 or containing only 0 as a min,
-            // so recalculate min and max with 0s included and fall back to linear
-            $('#log-scale-alert').show();
-            $('#y-log-scale').prop('checked',false);
-            logScale = null;
-            tmp = helpers.get_min_max(data, 'y', false);
-        } else {
-            $('#log-scale-alert').hide();
-        }
-
+        var tmp = helpers.get_min_max(data, 'y');
         var min_n = tmp[0];
         var max_n = tmp[1];
-
         var legend = d3.select(legend_selector)
             .append('svg')
             .attr('width', width);
@@ -217,8 +169,7 @@ define([
             'y',
             color_by,
             legend,
-            cohort_set,
-            logScale
+            cohort_set
         );
 
         return  {plot : plot, svg : svg}
@@ -227,29 +178,11 @@ define([
     /*
         Generate violin plot with axis swap
      */
-    function generate_violin_plot_axis_swap(margin, plot_selector, legend_selector, height, width, x_attr, y_attr, color_by, cohort_set, data, logScale) {
+    function generate_violin_plot_axis_swap(margin, plot_selector, legend_selector, height, width, x_attr, y_attr, color_by, cohort_set, data) {
         var violin_width = 200;
-        var tmp = helpers.get_min_max(data, 'x', logScale);
-
-        if(logScale && (tmp[0] == 0 || (tmp[1] > 0 && tmp[0] < 0))) {
-            // we don't currently support log scales crossing 0 or containing only 0 as a min,
-            // so recalculate min and max with 0s included and fall back to linear
-            $('#log-scale-alert').show();
-            $('#x-log-scale').prop('checked',false);
-            logScale = null;
-            tmp = helpers.get_min_max(data, 'x', false);
-        } else {
-            $('#log-scale-alert').hide();
-        }
-        
-        // Because we reverse what we send in, we need to reverse our logScale as well, or it will be wrong
-        if(helpers.LOG_SCALE.isScaleX(logScale)) {
-            logScale = helpers.LOG_SCALE.Y_LOG_SCALE;
-        }
-        
+        var tmp = helpers.get_min_max(data, 'x');
         var min_n = tmp[0];
         var max_n = tmp[1];
-
         var legend = d3.select(legend_selector)
             .append('svg')
             .attr('width', width);
@@ -271,8 +204,7 @@ define([
             'x',
             color_by,
             legend,
-            cohort_set,
-            logScale
+            cohort_set
         );
 
         return  {plot : plot, svg : svg}
@@ -402,8 +334,8 @@ define([
         var width  = $('.worksheet.active .worksheet-panel-body:first').width(), //TODO should be based on size of screen
             height = 700, //TODO ditto
             margin = {top: 0, bottom: 100, left: 70, right: 10},
-            x_type = args.data.types.x,
-            y_type = args.data.types.y;
+            x_type = '',
+            y_type = '';
 
         var data = args.data;
         if (data.hasOwnProperty('pairwise_result')) {
@@ -421,39 +353,22 @@ define([
                 args.color_by = 'c';
             }
 
-            var logScale = vizhelpers.LOG_SCALE.NO_LOG_SCALE;
-
             var visualization;
             switch (args.type){
                 case "Bar Chart" : //x_type == 'STRING' && y_type == 'none'
                     visualization = generate_bar_chart(margin, args.plot_selector, height, width, args.x, data);
                     break;
                 case "Histogram" : //((x_type == 'INTEGER' || x_type == 'FLOAT') && y_type == 'none') {
-                    if($('#x-log-scale').is(':checked')) {
-                        logScale = vizhelpers.LOG_SCALE.X_LOG_SCALE;
-                    }
-                    visualization = generate_histogram(margin, args.plot_selector, height, width, args.x, data, logScale, x_type);
+                    visualization = generate_histogram(margin, args.plot_selector, height, width, args.x, data);
                     break;
                 case 'Scatter Plot': //((x_type == 'INTEGER' || x_type == 'FLOAT') && (y_type == 'INTEGER'|| y_type == 'FLOAT')) {
-                    if($('#x-log-scale').is(':checked')) {
-                        logScale = vizhelpers.LOG_SCALE.X_LOG_SCALE;
-                    }
-                    if($('#y-log-scale').is(':checked')) {
-                        logScale = (logScale == vizhelpers.LOG_SCALE.X_LOG_SCALE ? vizhelpers.LOG_SCALE.BOTH_LOG_SCALE : vizhelpers.LOG_SCALE.Y_LOG_SCALE);
-                    }
-                    visualization = generate_scatter_plot(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by, cohort_set, data, logScale)
+                    visualization = generate_scatter_plot(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by, cohort_set, data)
                     break;
                 case "Violin Plot": //(x_type == 'STRING' && (y_type == 'INTEGER'|| y_type == 'FLOAT')) {
-                    if($('#y-log-scale').is(':checked')) {
-                        logScale = vizhelpers.LOG_SCALE.Y_LOG_SCALE;
-                    }
-                    visualization = generate_violin_plot(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by,  cohort_set, data, logScale)
+                    visualization = generate_violin_plot(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by,  cohort_set, data)
                     break;
                 case 'Violin Plot with axis swap'://(y_type == 'STRING' && (x_type == 'INTEGER'|| x_type == 'FLOAT')) {
-                    if($('#x-log-scale').is(':checked')) {
-                        logScale = vizhelpers.LOG_SCALE.X_LOG_SCALE;
-                    }
-                    visualization = generate_violin_plot_axis_swap(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by,  cohort_set, data, logScale)
+                    visualization = generate_violin_plot_axis_swap(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by,  cohort_set, data)
                     break;
                 case 'Cubby Hole Plot' : //(x_type == 'STRING' && y_type == 'STRING') {
                     visualization = generate_cubby_hole_plot(margin, args.plot_selector, args.legend_selector, height, width, args.x, args.y, args.color_by,  cohort_set, data)

--- a/static/js/workbooks.js
+++ b/static/js/workbooks.js
@@ -692,7 +692,7 @@ require([
         if(plot_type != "-- select an analysis --") {
             get_plot_model(workbook_id, worksheet_id, plot_type, function (data) {
                 if (data.error) {
-                    console.log("Display error");
+                    console.error("Display error");
                     callback(false);
                 } else {
                     load_plot(worksheet_id, data, plot_factory.get_plot_settings(plot_type), function (success) {

--- a/templates/workbooks/workbook_plot.html
+++ b/templates/workbooks/workbook_plot.html
@@ -97,9 +97,10 @@
                                 </div>
                             </div>
                         {% endfor %}
-                        <label for="x-log-scale">
+<!--                        <label for="x-log-scale">
                             <input id="x-log-scale" type="checkbox" class="log-scale"> Use log(x) for axis scale
                         </label>
+-->
                     </div>
 
                     <!-- Swap selection -->
@@ -157,9 +158,11 @@
                                 </div>
                             </div>
                         {% endfor %}
+<!--
                         <label for="y-log-scale">
                             <input id="y-log-scale" type="checkbox" class="log-scale"> Use log(y) for axis scale
                         </label>
+-->
                     </div>
 
                     <!-- Color By variable. only offer x and y selections-->


### PR DESCRIPTION
- Drop all log scaling for now
- Keep bugfixes found during enh 1328 implementation:
 - Don't plot 'NA' values
 - Split using regex to handle cases where category name contains :
 - When checking for numbers to parse, check for non-null, non-undefined,and a valid number-as-string before parsing