### PR TITLE
#1666, #1680, #1646

### DIFF
--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -323,6 +323,8 @@ require([
                     tokenFeatDisplName = (feature.data('feature-displ-name') && feature.data('feature-displ-name').length > 0) ?
                      feature.data('feature-displ-name') : feature.data('feature-name');
 
+                var feature_id = feature.data('feature-id'), value_id =  value.data('value-id');
+
                 if (feature.data('feature-type') == 'datatype') { // Datatype feature
                     var feature_value = value.data('value-name').split('-');
 
@@ -338,83 +340,90 @@ require([
                             break;
                     }
 
+                    feature_id = 'SAMP:' + feature_value[0];
+
+
+
                     var token = $('<span>').data({
-                        'feature-id': 'SAMP:' + feature_value[0],
+                        'feature-id': feature_id,
                         'feature-name': feature_value[0],
-                        'value-id': value.data('value-id'),
+                        'value-id': value_id,
                         'value-name': feature_value[1]
-                    });
+                    }).attr('data-feature-id',feature_id).attr('data-value-id',value_id);
 
                 } else if (feature.data('feature-type') == 'donor') { // Donor feature
                     token = $('<span>').data({
-                        'feature-id': feature.data('feature-id'),
+                        'feature-id': feature_id,
                         'feature-name': feature.data('feature-name'),
-                        'value-id': value.data('value-id'),
+                        'value-id': value_id,
                         'value-name': value.data('value-name')
-                    });
+                    }).attr('data-feature-id',feature_id).attr('data-value-id',value_id);
+
                 } else if (feature.data('feature-type') == 'user-data') { // User data filter
                     token = $('<span>').data({
-                        'feature-id': feature.data('feature-id'),
+                        'feature-id': feature_id,
                         'feature-name': feature.data('feature-name'),
-                        'value-id': value.data('value-id'),
+                        'value-id': value_id,
                         'value-name': value.data('value-name')
-                    });
-                } else { // Molecular feature
+                    }).attr('data-feature-id',feature_id).attr('data-value-id',value_id);
 
+                } else { // Molecular feature
                     var gene = geneListField.tokenfield('getTokens')[0];
+                    feature_id = 'MUT:'+gene.value + ':' + feature.data('feature-id');
+
                     token = $('<span>').data({
-                        'feature-id': 'MUT:'+gene.value + ':' + feature.data('feature-id'),
+                        'feature-id': feature_id,
                         'feature-type': 'molecular',
                         'feature-name': feature.data('feature-name'),
-                        'value-id': value.data('value-id'),
+                        'value-id': value_id,
                         'value-name': value.data('value-name')
-                    });
+                    }).attr('data-feature-id',feature_id).attr('data-value-id',value_id);
 
                     tokenFeatDisplName = gene.label + ' [' + feature.data('feature-displ-name');
                     tokenValDisplName += ']'
                 }
 
-                token.append(
-                    $('<a>').addClass('delete-x filter-label label label-default')
-                        .text(tokenFeatDisplName + ': ' + tokenValDisplName)
-                        .append('<i class="fa fa-times">')
-                        .attr("title",tokenFeatDisplName + ': ' + tokenValDisplName)
-                );
+                // Don't re-add the token and filter if it already exists
+                if($('.selected-filters .panel-body span[data-feature-id="'+feature_id+'"][data-value-id="'+value_id+'"]').length <= 0) {
+                    token.append(
+                        $('<a>').addClass('delete-x filter-label label label-default')
+                            .text(tokenFeatDisplName + ': ' + tokenValDisplName)
+                            .append('<i class="fa fa-times">')
+                            .attr("title",tokenFeatDisplName + ': ' + tokenValDisplName)
+                    );
 
-                if (feature.data('feature-type') == 'molecular') {
-                    token.find('a.delete-x').addClass('mol-spec-filter-x');
-                }
-
-                $this.data({
-                    'select-filters-item': token.clone(true),
-                    'create-cohort-form-item': token.clone(true)
-                });
-
-                $('.selected-filters .panel-body').append($this.data('select-filters-item'));
-                $('#create-cohort-form .form-control-static').append($this.data('create-cohort-form-item'));
-
-                $('a.delete-x').on('click', function(e,data) {
-                    var checked_box = $('div[data-feature-id="' + $(this).parent('span').data('feature-id')
-                        + '"] input[type="checkbox"][data-value-name="' + $(this).parent('span').data('value-name') + '"]');
-
-                    if($(this).parent('span').data('feature-type') == 'molecular') {
-                        checked_box = $('div[data-feature-id="' + $(this).parent('span').data('feature-id').split(":")[2]
-                            + '"] input[type="checkbox"][data-value-name="' + $(this).parent('span').data('value-name') + '"]');
+                    if (feature.data('feature-type') == 'molecular') {
+                        token.find('a.delete-x').addClass('mol-spec-filter-x');
                     }
-                    checked_box.prop('checked', false);
-                    var span_data = $(this).parent('span').data();
-                    $(this).parent('span').remove();
 
-                    // Remove create cohort form pill
-                    $('#create-cohort-form .form-control-static span').each(function () {
-                        if ($(this).data('feature-id') == span_data['feature-id'] && $(this).data('value-name') == span_data['value-name']) {
-                            $(this).remove();
-                        }
+                    $this.data({
+                        'select-filters-item': token.clone(true),
+                        'create-cohort-form-item': token.clone(true)
                     });
 
-                    (!data || !data.without_update) && update_displays(true);
-                    return false;
-                });
+
+                    $('.selected-filters .panel-body').append($this.data('select-filters-item'));
+                    $('#create-cohort-form .form-control-static').append($this.data('create-cohort-form-item'));
+
+                    $('a.delete-x').on('click', function(e,data) {
+                        var checked_box = $('div[data-feature-id="' + $(this).parent('span').data('feature-id')
+                            + '"] input[type="checkbox"][data-value-name="' + $(this).parent('span').data('value-name') + '"]');
+
+                        if($(this).parent('span').data('feature-type') == 'molecular') {
+                            checked_box = $('div[data-feature-id="' + $(this).parent('span').data('feature-id').split(":")[2]
+                                + '"] input[type="checkbox"][data-value-name="' + $(this).parent('span').data('value-name') + '"]');
+                        }
+                        checked_box.prop('checked', false);
+                        var span_data = $(this).parent('span').data();
+
+                        // Remove the filter tokens from their respective containers
+                        $('#create-cohort-form .form-control-static span[data-feature-id="'+span_data['feature-id']+'"][data-value-id="'+span_data['value-id']+'"]').remove();
+                        $('.selected-filters .panel-body span[data-feature-id="'+span_data['feature-id']+'"][data-value-id="'+span_data['value-id']+'"]').remove();
+
+                        (!data || !data.without_update) && update_displays(true);
+                        return false;
+                    });
+                }
             } else { // Checkbox unchecked
                 // Remove create cohort form pill if it exists
                 if($this.data('create-cohort-form-item')) {

--- a/static/js/helpers/search_helpers.js
+++ b/static/js/helpers/search_helpers.js
@@ -44,13 +44,17 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
             clin_tree_attr.map(function(attr){
                 clin_tree_attr_map[attr] = 1;
             });
-            for(var i=0;i<filters.length;i++) {
-                var fname = filters[i].key.split(/:/)[1];
-                if(clin_tree_attr_map[fname]) {
-                    if(!filtered_clin_trees[fname]) {
-                        filtered_clin_trees[fname] = {};
+            for(var i in filters) {
+                if(filters.hasOwnProperty(i)) {
+                    var fname = i.split(/:/)[1];
+                    if (clin_tree_attr_map[fname]) {
+                        if (!filtered_clin_trees[fname]) {
+                            filtered_clin_trees[fname] = {};
+                        }
+                        filters[i].map(function(val){
+                            filtered_clin_trees[fname][val] = 1;
+                        });
                     }
-                    filtered_clin_trees[fname][filters[i].value] = 1;
                 }
             }
             if(Object.keys(filtered_clin_trees).length > 0) {
@@ -90,7 +94,7 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
             // If there were filters, we need to adjust their counts so the barchart reflects what
             // was actually filtered
             var filters = this.format_filters();
-            var clin_tree_attr_counts = filters.length > 0 ? this.filter_data_for_clin_trees(attr_counts) : attr_counts;
+            var clin_tree_attr_counts = Object.keys(filters).length > 0 ? this.filter_data_for_clin_trees(attr_counts) : attr_counts;
 
             tree_graph_obj.draw_trees(clin_tree_attr_counts,clin_tree_attr);
 
@@ -169,7 +173,7 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
                     $('#total-participants').html(results['participants']);
                     update_filters(attr_counts);
 
-                    var attr_counts_clin_trees = filters.length > 0 ? context.filter_data_for_clin_trees(attr_counts) : attr_counts;
+                    var attr_counts_clin_trees = Object.keys(filters).length > 0 ? context.filter_data_for_clin_trees(attr_counts) : attr_counts;
 
                     tree_graph_obj.draw_trees(attr_counts_clin_trees,clin_tree_attr);
                     

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -121,7 +121,7 @@
                                                         <li class="checkbox">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}"
-                                                                       data-value-id="{% if v.id %}{{ v.id }}{% endif %}"
+                                                                       data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}"
                                                                        data-value-displ-name="{% if v.displ_name %}{{ v.displ_name }}{% endif %}">
                                                                 {% if v.value == 'None' %}NA{% elif v.displ_name %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                  <span class="count">({{ v.count }})</span>
@@ -132,7 +132,7 @@
                                                         <li class="extra-values checkbox" style="display:none;">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}"
-                                                                       data-value-id="{% if v.id %}{{ v.id }}{% endif %}"
+                                                                       data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}"
                                                                        data-value-displ-name="{% if v.displ_name %}{{ v.displ_name }}{% endif %}">
                                                                 {% if v.value == 'None' %}NA{% elif v.displ_name %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                  <span class="count">({{ v.count }})</span>
@@ -142,7 +142,7 @@
                                                         <li class="extra-values checkbox" style="display:none;">
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}"
-                                                                       data-value-id="{% if v.id %}{{ v.id }}{% endif %}"
+                                                                       data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}"
                                                                        data-value-displ-name="{% if v.displ_name %}{{ v.displ_name }}{% endif %}">
                                                                 {% if v.value == 'None' %}NA{% elif v.displ_name %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                  <span class="count">({{ v.count }})</span>
@@ -238,7 +238,8 @@
                                                 <option value="label" disabled>-- Select a Mutation Category --</option>
                                                 <option value="any" data-value-displ-name="Any" data-value-name="Any" data-value-id="any">Any</option>
                                                 {% for cat in molecular_attr.categories %}
-                                                    <option value="{{ cat.value }}" data-value-displ-name="{{ cat.name }}" data-value-name="{{ cat.name }}" data-value-id="{{ cat.value }}">{{ cat.name }}</option>
+                                                    <option value="{{ cat.value }}" data-value-displ-name="{{ cat.name }}" data-value-name="{{ cat.name }}"
+                                                            data-value-id="{% if cat.id %}{{ cat.id }}{% else %}{{ cat.value }}{% endif %}">{{ cat.name }}</option>
                                                 {% endfor %}
                                                 <option value="indv-selex">Individual Selection</option>
                                             </select>
@@ -295,7 +296,7 @@
                                         {% for v in attr.values %}
                                             <li class="checkbox">
                                                 <label>
-                                                    <input type="checkbox" name="elements-selected" data-value-name="{{ v.id }}"
+                                                    <input type="checkbox" name="elements-selected" data-value-name="{{ v.id }}" data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}"
                                                            data-value-displ-name="{% if v.display_name %}{{ v.displ_name }}{% elif v.name %}{{ v.name }}{% else %}{{ v.id }}{% endif %}">
                                                     {% if v.display_name %}{{ v.displ_name }}{% elif v.name %}{{ v.name }}{% else %}{{ v.id }}{% endif %} <span class="count">({{ v.count }})</span>
                                                 </label>

--- a/templates/cohorts/new_cohort.html
+++ b/templates/cohorts/new_cohort.html
@@ -263,13 +263,14 @@
                                 </div>
                                 <div id="collapse-{{ attr.id }}" class="list-group-item__body collapse cohort-feature-select-block" role="tabpanel"
                                      aria-labelledby="heading-{{ attr.id }}" data-feature-name="{{ attr.name }}" data-feature-id="{{ attr.id }}"
-                                     data-feature-displ-name="{% if attr.displ_name %}{{ attr.displ_name }}{% elif attr.name %}{{ attr.name }}{% else %}{{ attr.id }}{% endif %}" data-feature-type="user-data">
+                                     data-feature-displ-name="{% if attr.displ_name %}{{ attr.displ_name }}{% elif attr.name %}{{ attr.name }}{% else %}{{ attr.id }}{% endif %}"
+                                     data-feature-type="user-data">
                                     <ul class="search-checkbox-list" id="{{ attr.id }}">
                                         {% for v in attr.values %}
                                             <li class="checkbox">
                                                 <label>
                                                     <input type="checkbox" name="elements-selected" data-value-name="{{ v.name }}"
-                                                           data-value-id="{% if v.id %}{{ v.id }}{% else %}{{ v.name }}{% endif %}"
+                                                           data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}"
                                                            data-value-displ-name="{% if v.display_name %}{{ v.displ_name }}{% elif v.name %}{{ v.name }}{% else %}{{ v.id }}{% endif %}">
                                                     {% if v.display_name %}{{ v.displ_name }}{% elif v.name %}{{ v.name }}{% else %}{{ v.id }}{% endif %} <span class="count">({{ v.count }})</span>
                                                 </label>

--- a/templates/cohorts/new_cohort.html
+++ b/templates/cohorts/new_cohort.html
@@ -92,7 +92,7 @@
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}"
                                                                        data-value-displ-name="{% if v.displ_name %}{{ v.displ_name }}{% endif %}"
-                                                                       data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
+                                                                       data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}">
                                                                 {% if v.value == 'None' %}NA{% elif v.displ_name %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                  <span class="count">({{ v.count }})</span>
                                                             </label>
@@ -103,7 +103,7 @@
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}"
                                                                        data-value-displ-name="{% if v.displ_name %}{{ v.displ_name }}{% endif %}"
-                                                                       data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
+                                                                       data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}">
                                                                 {% if v.value == 'None' %}NA{% elif v.displ_name %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                  <span class="count">({{ v.count }})</span>
                                                             </label>
@@ -113,7 +113,7 @@
                                                             <label title="{{ v.value|get_tooltip_text:attr }}">
                                                                 <input type="checkbox" name="elements-selected" data-value-name="{{ v.value }}"
                                                                        data-value-displ-name="{% if v.displ_name %}{{ v.displ_name }}{% endif %}"
-                                                                       data-value-id="{% if v.id %}{{ v.id }}{% endif %}">
+                                                                       data-value-id="{% if v.id %}{{ v.id }}{% elif v.name %}{{ v.name }}{% else %}{{ v.value }}{% endif %}">
                                                                 {% if v.value == 'None' %}NA{% elif v.displ_name %}{{ v.displ_name|get_readable_name:attr }}{% else %}{{ v.value|get_readable_name:attr }}{% endif %}
                                                                  <span class="count">({{ v.count }})</span>
                                                             </label>
@@ -208,7 +208,8 @@
                                                 <option value="label" disabled>-- Select a Mutation Category --</option>
                                                 <option value="any" data-value-displ-name="Any" data-value-name="Any" data-value-id="any">Any</option>
                                                 {% for cat in molecular_attr.categories %}
-                                                    <option value="{{ cat.value }}" data-value-displ-name="{{ cat.name }}" data-value-name="{{ cat.name }}" data-value-id="{{ cat.value }}">{{ cat.name }}</option>
+                                                    <option value="{{ cat.value }}" data-value-displ-name="{{ cat.name }}" data-value-name="{{ cat.name }}"
+                                                            data-value-id="{% if cat.id %}{{ cat.id }}{% else %}{{ cat.value }}{% endif %}">{{ cat.name }}</option>
                                                 {% endfor %}
                                                 <option value="indv-selex">Individual Selection</option>
                                             </select>
@@ -228,7 +229,8 @@
                                                     <li class="checkbox">
                                                         <label>
                                                             <input class="mutation-checkbox" type="checkbox" name="elements-selected" data-value-name="{{ attr.value }}"
-                                                                   data-value-id="{{ attr.value }}" data-value-displ-name="{{ attr.name }}" data-category="{{ attr.category }}">
+                                                                   data-value-id="{% if attr.id %}{{ attr.id }}{% else %}{{ attr.value }}{% endif %}"
+                                                                   data-value-displ-name="{{ attr.name }}" data-category="{{ attr.category }}">
                                                             {{ attr.name }} <!-- <span class="count">({{ attr.count }})</span> -->
                                                         </label>
                                                     </li>
@@ -266,7 +268,8 @@
                                         {% for v in attr.values %}
                                             <li class="checkbox">
                                                 <label>
-                                                    <input type="checkbox" name="elements-selected" data-value-name="{{ v.name }}"  data-value-id="{{ v.id }}"
+                                                    <input type="checkbox" name="elements-selected" data-value-name="{{ v.name }}"
+                                                           data-value-id="{% if v.id %}{{ v.id }}{% else %}{{ v.name }}{% endif %}"
                                                            data-value-displ-name="{% if v.display_name %}{{ v.displ_name }}{% elif v.name %}{{ v.name }}{% else %}{{ v.id }}{% endif %}">
                                                     {% if v.display_name %}{{ v.displ_name }}{% elif v.name %}{{ v.name }}{% else %}{{ v.id }}{% endif %} <span class="count">({{ v.count }})</span>
                                                 </label>


### PR DESCRIPTION
Fixes for:
- #1666, the Clinical Features trees not showing the full filter set
- #1646, filter token duplication when using check/uncheck all
- #1680, trailing filter tokens resulting in duplication when a token was unselected in the Save Cohort modal