### PR TITLE
User Data display upgrades

### DIFF
--- a/static/js/helpers/search_helpers.js
+++ b/static/js/helpers/search_helpers.js
@@ -89,8 +89,8 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
 
             $('#isb-cgc-data-total-samples').html(metadata_counts['total']);
             $('#isb-cgc-data-total-participants').html(metadata_counts['participants']);
-            user_data && $('#user-data-total-samples').html(user_data['total']);
-            user_data && $('#user-data-total-participants').html(user_data['participants']);
+            $('#user-data-total-samples').html(user_data ? metadata_counts['user_data_total'] : "NA");
+            $('#user-data-total-participants').html(user_data ? metadata_counts['user_data_participants'] : "NA");
 
 
             this.update_filter_counts(attr_counts);
@@ -172,8 +172,10 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
                     var stopReq = new Date().getTime();
                     console.debug("[BENCHMARKING] Time for response in update_counts_parsets: "+(stopReq-startReq)+ "ms");
                     attr_counts = results['count'];
-                    $('#total-samples').html(results['total']);
-                    $('#total-participants').html(results['participants']);
+                    $('#isb-cgc-data-total-samples').html(results['total']);
+                    $('#isb-cgc-data-total-participants').html(results['participants']);
+                    $('#user-data-total-samples').html(results['user_data'] ? results['user_data_total'] : "NA");
+                    $('#user-data-total-participants').html(results['user_data'] ? results['user_data_participants'] : "NA");
                     update_filters(attr_counts);
 
                     var attr_counts_clin_trees = Object.keys(filters).length > 0 ? context.filter_data_for_clin_trees(attr_counts) : attr_counts;
@@ -212,8 +214,10 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
                     }
                 },
                 error: function(req,status,err){
-                    $('#total-samples').html("Error");
-                    $('#total-participants').html("Error");
+                    $('#isb-cgc-data-total-samples').html("Error");
+                    $('#isb-cgc-data-total-participants').html("Error");
+                    $('#user-data-total-samples').html("Error");
+                    $('#user-data-total-participants').html("Error");
                 },
                 complete: function(xhr,status) {
                     $('.clinical-trees .spinner').hide();

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -100,8 +100,8 @@
         <div class="col-lg-4">
             <div class="panel panel-default">
                 <ul class="nav nav-tabs nav-tabs-data" role="tablist">
-                    <li role="presentation" class="active"><a href="#isb-cgc-data" role="tab" data-toggle="tab" title="Donor Filters">ISB-CGC Data</a></li>
-                    <li role="presentation" class=""><a href="#user-data" role="tab" data-toggle="tab" title="User Data">User Data</a></li>
+                    <li role="presentation" class="{% if not user_data or metadata_counts.user_data_total <= 0 %}active{% endif %}"><a href="#isb-cgc-data" role="tab" data-toggle="tab" title="Donor Filters">ISB-CGC Data</a></li>
+                    <li role="presentation" class="{% if user_data and metadata_counts.user_data_total > 0 %}active{% endif %}"><a href="#user-data" role="tab" data-toggle="tab" title="User Data">User Data</a></li>
                 </ul>
             </div>
         </div>

--- a/templates/cohorts/isb-cgc-data.html
+++ b/templates/cohorts/isb-cgc-data.html
@@ -216,12 +216,12 @@
                         <div class="row col-md-6">
                             <span class="detail-label">Total Number of Samples:</span>
                             <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                            <span class="total-values" id="isb-cgc-data-total-samples">TBD</span>
+                            <span class="total-values" id="isb-cgc-data-total-samples">{{ metadata_counts.total }}</span>
                         </div>
                         <div class="row col-md-6">
                             <span class="detail-label">Total Number of Participants:</span>
                             <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                            <span class="total-values" id="isb-cgc-data-total-participants">TBD</span>
+                            <span class="total-values" id="isb-cgc-data-total-participants">{{ metadata_counts.participants }}</span>
                         </div>
                     </div>
                 </div>

--- a/templates/cohorts/isb-cgc-data.html
+++ b/templates/cohorts/isb-cgc-data.html
@@ -1,4 +1,4 @@
-        <div id="isb-cgc-data" class="tab-pane active data-tab" role="tabpanel">
+        <div id="isb-cgc-data" class="tab-pane data-tab {% if not user_data or metadata_counts.user_data_total <= 0 %}active{% endif %}" role="tabpanel">
             <div id="isb-cgc-data-filter-panel" class="col-lg-4 filter-panel" role="tabpanel" {% if cohort.id %}style="display:none;"{% endif %}>
                 <div class="tabpanel" role="tabpanel">
                     <ul class="nav nav-tabs nav-tabs-filters" role="tablist">

--- a/templates/cohorts/new_cohort.html
+++ b/templates/cohorts/new_cohort.html
@@ -94,7 +94,7 @@
                 </div>
                 <div id="one-cohort-type-per-create-warn" class="alert alert-warning alert-dismissable" style="display: none;">
                     <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    A cohort can only be made with ISB-CGC Data <b>or</b> User Data filters, not with both. Because the <span class="one-per-warn"></span> tab was active,
+                    A cohort can only be filtered with ISB-CGC Data <b>or</b> User Data filters, not with both. Because the <span class="one-per-warn"></span> tab was active,
                     we have chosen those filters. If you wish to create your cohort with the other filter set, cancel this dialog (using the X in the upper-right corner) and
                     switch to that tab before clicking the <b>Save as New Cohort</b> button.
                 </div>

--- a/templates/cohorts/user-data.html
+++ b/templates/cohorts/user-data.html
@@ -1,4 +1,4 @@
-<div id="user-data" class="tab-pane data-tab" role="tabpanel">
+<div id="user-data" class="tab-pane data-tab {% if user_data and metadata_counts.user_data_total > 0 %}active{% endif %}" role="tabpanel">
     <div id="user-data-filter-panel" class="col-lg-4 filter-panel" role="tabpanel" {% if cohort.id %}style="display:none;"{% endif %}>
         <div class="tabpanel" role="tabpanel">
             <ul class="nav nav-tabs nav-tabs-ud-filters" role="tablist">

--- a/templates/cohorts/user-data.html
+++ b/templates/cohorts/user-data.html
@@ -9,6 +9,14 @@
                 <!-- user data projects & studies filters tab -->
                 <div role="tabpanel" class="tab-pane active" id="ud-proj-study-filters">
                     <ul class="list-group" id="data-type-accordion" role="tablist" aria-multiselectable="true">
+                        {% if not user_data or metadata_counts.user_data_total <= 0 %}
+                            <li class="list-group-item">
+                                <div id="user-data-alert" class="alert alert-warning alert-dismissable">
+                                    <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                                    There is no user data available to display.
+                                </div>
+                            </li>
+                        {% endif %}
                         {% for attr in user_data %}
                             <li class="list-group-item">
                                 <div class="list-group-item__heading" role="tab" id="heading-{{ attr.id }}">
@@ -111,12 +119,12 @@
                 <div class="row col-md-6">
                     <span class="detail-label">Total Number of Samples:</span>
                     <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                    <span class="total-values" id="user-data-total-samples">TBD</span>
+                    <span class="total-values" id="user-data-total-samples">{% if user_data %}{{ metadata_counts.user_data_total  }}{% else %}NA{% endif %}</span>
                 </div>
                 <div class="row col-md-6">
                     <span class="detail-label">Total Number of Participants:</span>
                     <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                    <span class="total-values" id="user-data-total-participants">TBD</span>
+                    <span class="total-values" id="user-data-total-participants">{% if user_data %}{{ metadata_counts.user_data_participants  }}{% else %}NA{% endif %}</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- If a cohort contains user data, or if user data is available on a new cohort, that will be the active tab, otherwise the ISB-CGC tab will be active when either the cohort editing or creation pages are loaded
- User data sample and participant total counts should now be accurate; note that if a user hasn't provided participant barcodes in their upload, that number will be 0

***Note:*** Require PR #57 from Common