### PR TITLE
Catchup scripts: upgrades and CCLE

### DIFF
--- a/scripts/database_catchup_scripts.py
+++ b/scripts/database_catchup_scripts.py
@@ -167,7 +167,7 @@ def fix_cohort_studies(cursor):
         FROM cohorts_samples cs
                 JOIN metadata_samples ms
                         ON ms.SampleBarcode = cs.sample_id
-                JOIN (SELECT id,name FROM projects_study WHERE owner_id = 1 AND actice = 1) ps
+                JOIN (SELECT id,name FROM projects_study WHERE owner_id = 1 AND active = 1) ps
                         ON ps.name = ms.Study
                 JOIN cohorts_cohort AS cc
                         ON cc.id = cs.cohort_id

--- a/scripts/database_catchup_scripts.py
+++ b/scripts/database_catchup_scripts.py
@@ -152,12 +152,14 @@ def fix_cohort_studies(cursor):
         JOIN (
                 SELECT ms.SampleBarcode AS SampleBarcode,ps.id AS study
                         FROM metadata_samples ms
-                                JOIN (SELECT id,name FROM projects_study WHERE owner_id = 1) ps
+                                JOIN (SELECT id,name FROM projects_study WHERE owner_id = 1 AND active=1) ps
                         ON ps.name = ms.Study
         ) AS ss
         ON ss.SampleBarcode = cs.sample_id
+        JOIN cohorts_cohort AS cc
+        ON cc.id = cs.cohort_id
         SET cs.study_id = ss.study
-        WHERE cs.study_id IS NULL;
+        WHERE cs.study_id IS NULL AND cc.active = 1;
     """
 
     null_study_count = """
@@ -165,9 +167,11 @@ def fix_cohort_studies(cursor):
         FROM cohorts_samples cs
                 JOIN metadata_samples ms
                         ON ms.SampleBarcode = cs.sample_id
-                JOIN (SELECT id,name FROM projects_study WHERE owner_id = 1) ps
+                JOIN (SELECT id,name FROM projects_study WHERE owner_id = 1 AND actice = 1) ps
                         ON ps.name = ms.Study
-        where cs.study_id IS NULL;
+                JOIN cohorts_cohort AS cc
+                        ON cc.id = cs.cohort_id
+        where cs.study_id IS NULL AND cc.active = 1;
     """
 
     cursor.execute(null_study_count)

--- a/scripts/database_catchup_scripts.py
+++ b/scripts/database_catchup_scripts.py
@@ -144,6 +144,8 @@ def create_samples_shortlist_view(cursor):
 # Cohorts made prior to the release of user data will have null values in their study IDs for each sample
 # in the cohort. This script assumes that any sample with a null study ID is an ISB-CGC sample from metadata_samples
 # and uses the value of the Study column to look up the appropriate ID in projects_study and apply it to the cohort
+# *** This will need to be changed when metadata_samples.Study becomes 'disease code' and a study column is added ***
+# *** which is an FK into the projects_study table                                                                ***
 
 def fix_cohort_studies(cursor):
 
@@ -186,7 +188,8 @@ def fix_cohort_studies(cursor):
         print >> sys.stdout, "[WARNING] Some of the samples were not corrected! You should double-check them."
 
 
-# Query to correct CCLE samples, which ran into the 'disease code' and 'study' collision problem
+# Query to correct CCLE samples from fix_cohort_samples, because despite having specific 'Study' values all CCLE samples are
+# part of a single CCLE study
 
 def fix_ccle(cursor):
 


### PR DESCRIPTION
- Added a fix for CCLE, which is a different behavior than the other samples and studies
- Only active studies will be considered for study IDs to go into cohorts_samples
- Only active cohorts will be fixed