### PR TITLE
Viz upgrades and fixes: #1711, 1724, #1040, #1599

### DIFF
--- a/static/js/visualizations/createBarGraph.js
+++ b/static/js/visualizations/createBarGraph.js
@@ -91,6 +91,7 @@ define (['jquery', 'd3', 'd3tip', 'd3textwrap', 'vizhelpers'],
 
             var zoom = d3.behavior.zoom()
                 .x(x2)
+                .scaleExtent([1,1])
                 .on('zoom', zoomer);
 
             svg.call(zoom);

--- a/static/js/visualizations/createBarGraph.js
+++ b/static/js/visualizations/createBarGraph.js
@@ -17,7 +17,7 @@
  */
 
 define (['jquery', 'd3', 'd3tip', 'd3textwrap', 'vizhelpers'],
-function($, d3, d3tip, d3textwrap, vizhelpers) {
+    function($, d3, d3tip, d3textwrap, vizhelpers) {
 
     // If you want to override the tip coming in from the create call,
     // do it here

--- a/static/js/visualizations/createBarGraph.js
+++ b/static/js/visualizations/createBarGraph.js
@@ -71,13 +71,15 @@ define (['jquery', 'd3', 'd3tip', 'd3textwrap', 'vizhelpers'],
                 .orient('bottom');
             var y = d3.scale.linear()
                 .range([height-margin.bottom-margin.top, 0])
-                .domain([0, d3.max(data, function(d) { return d.count; })]);
+                .domain([0, d3.max(data, function(d) { return d.count; })])
+                .nice();
             var yAxis = d3.svg.axis()
                 .scale(y)
                 .orient('left')
                 .tickSize(-width + margin.right + margin.left, 0, 0);
 
             var zoomer = function() {
+                console.debug(d3.event.translate);
                 if(!selex_active) {
                     svg.select('.x.axis').attr('transform', 'translate(' + (d3.event.translate[0] + margin.left) + ',' + (height - margin.bottom - 55) + ')').call(xAxis);
                     svg.selectAll('.x.axis text').style('text-anchor', 'end').attr('transform', 'translate(' + -15 + ',' + 10 + ') rotate(-90)');

--- a/static/js/visualizations/createBarGraph.js
+++ b/static/js/visualizations/createBarGraph.js
@@ -79,7 +79,6 @@ define (['jquery', 'd3', 'd3tip', 'd3textwrap', 'vizhelpers'],
                 .tickSize(-width + margin.right + margin.left, 0, 0);
 
             var zoomer = function() {
-                console.debug(d3.event.translate);
                 if(!selex_active) {
                     svg.select('.x.axis').attr('transform', 'translate(' + (d3.event.translate[0] + margin.left) + ',' + (height - margin.bottom - 55) + ')').call(xAxis);
                     svg.selectAll('.x.axis text').style('text-anchor', 'end').attr('transform', 'translate(' + -15 + ',' + 10 + ') rotate(-90)');

--- a/static/js/visualizations/createCubbyPlot.js
+++ b/static/js/visualizations/createCubbyPlot.js
@@ -214,17 +214,9 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
             var x2 = d3.scale.linear()
                 .range([0, width])
                 .domain([0, width]);
-            var x2Axis = d3.svg.axis()
-                .scale(x2)
-                .ticks(domain.length)
-                .tickFormat('');
             var y2 = d3.scale.linear()
-                .range([0, width])
-                .domain([0, width]);
-            var y2Axis = d3.svg.axis()
-                .scale(y2)
-                .ticks(range.length)
-                .tickFormat('');
+                .range([0, height])
+                .domain([0, height]);
 
             var zoom_x = function() {
                 if(!selex_active) {
@@ -243,9 +235,9 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
                         .style('text-anchor', 'middle')
                         .attr('dy', -10);
                     svg.select('.y.grid').attr('transform', 'translate(' + margin.left + ',' + (d3.event.translate[1] + (Math.round((-cubby_size) / 2))) + ')');
+
                     plot_area.selectAll('.expected_fill').attr('transform', 'translate(' + 0 + ',' + d3.event.translate[1] + ')');
                     plot_area.selectAll('text').attr('transform', 'translate(' + 0 + ',' + d3.event.translate[1] + ')');
-                    d3.select('.y.axis').selectAll('foreignObject').attr('style', 'transform: translate(-' + margin.left * 0.75 + 'px,-' + y.rangeBand() * 0.50 + 'px);');;
                 }
             };
 
@@ -257,15 +249,16 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
                         svg.select('.x.axis').attr('transform', 'translate(' + d3.event.translate[0] + ',' + (view_height - margin.top - margin.bottom) + ') scale(' + d3.event.scale + ',' + d3.event.scale + ')').call(xAxis);
                     }
                     svg.select('.x.grid').attr('transform', 'translate(' + (d3.event.translate[0] + x_band_width / 2) + ',0) scale(' + d3.event.scale + ',' + d3.event.scale + ')');
+
                     svg.select('.y.axis').attr('transform', 'translate(' + margin.left + ',' + (d3.event.translate[1]) + ') scale(' + d3.event.scale + ',' + d3.event.scale + ')')
                         .call(yAxis)
                         .selectAll('text')
                         .style('text-anchor', 'middle')
                         .attr('dy', -10);
                     svg.select('.y.grid').attr('transform', 'translate(' + margin.left + ',' + (d3.event.translate[1] + (y_band_width * d3.event.scale) / 2) + ') scale(' + d3.event.scale + ',' + d3.event.scale + ')');
+
                     plot_area.selectAll('.expected_fill').attr('transform', 'translate(' + d3.event.translate[0] + ',' + d3.event.translate[1] + ') scale(' + d3.event.scale + ',' + d3.event.scale + ')');
                     plot_area.selectAll('text').attr('transform', 'translate(' + d3.event.translate[0] + ',' + d3.event.translate[1] + ') scale(' + d3.event.scale + ',' + d3.event.scale + ')');
-                    d3.select('.y.axis').selectAll('foreignObject').attr('style', 'transform: translate(-' + margin.left * 0.75 + 'px,-' + y.rangeBand() * 0.50 + 'px);');
                 }
             };
 
@@ -367,8 +360,6 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
                 .attr('text-anchor', 'middle')
                 .attr('transform', 'translate(' + xAxisXPos + ',' + xAxisYPos + ')')
                 .text(xLabel);
-            d3.select('.x.axis').selectAll('text').call(d3textwrap.textwrap().bounds({width: x.rangeBand(), height: margin.bottom*0.75}));
-            d3.select('.x.axis').selectAll('foreignObject').attr('style','transform: translate(-'+(x.rangeBand()*0.5)+'px,0px);');
 
             var yAxisXPos = (parseInt(svg.attr('height')>view_height ? view_height : svg.attr('height'))-margin.bottom)/2;
             svg.append('text')
@@ -377,12 +368,17 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
                 .attr('transform', 'rotate(-90) translate(-' + yAxisXPos + ',10)')
                 .text(yLabel);
 
+            // Wrap our value labels
+            d3.select('.x.axis').selectAll('text').call(d3textwrap.textwrap().bounds({width: x.rangeBand(), height: margin.bottom*0.75}));
+            d3.select('.x.axis').selectAll('foreignObject')
+                .attr('style','transform: translate(-'+(x.rangeBand()*0.5)+'px,0px);');
+
             d3.select('.y.axis').selectAll('text').call(d3textwrap.textwrap().bounds({width: margin.left*0.75, height: y.rangeBand()}));
             d3.select('.y.axis').selectAll('foreignObject')
                 .attr('style','transform: translate(-'+margin.left*0.75+'px,-'+y.rangeBand()*0.50+'px);');
 
             $('foreignObject div').each(function(){
-                $(this).attr('title',$(this).html());
+                $(this).attr('title',$(this).html())
             });
 
             var check_selection_state = function(obj) {

--- a/static/js/visualizations/createCubbyPlot.js
+++ b/static/js/visualizations/createCubbyPlot.js
@@ -267,15 +267,19 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
             if (width > view_width && height> view_height) {
                 zoom = d3.behavior.zoom()
                     .x(x2)
+                    .scaleExtent([1,1])
                     .y(y2)
+                    .scaleExtent([1,1])
                     .on('zoom', zoom_xy);
             } else if (width > view_width) {
                 zoom = d3.behavior.zoom()
                     .x(x2)
+                    .scaleExtent([1,1])
                     .on('zoom', zoom_x);
             } else if (height > view_height) {
                 zoom = d3.behavior.zoom()
                     .y(y2)
+                    .scaleExtent([1,1])
                     .on('zoom', zoom_y);
             }
 

--- a/static/js/visualizations/createHistogram.js
+++ b/static/js/visualizations/createHistogram.js
@@ -16,8 +16,9 @@
  *
  */
 
-define(['jquery', 'd3', 'd3tip', 'vizhelpers'],
-function($, d3, d3tip, helpers) {
+define(['jquery', 'd3', 'd3tip', 'd3textwrap', 'vizhelpers'],
+    function($, d3, d3tip, d3textwrap, helpers) {
+
     var svg;
     var margin;
     var zoom_area;

--- a/static/js/visualizations/createScatterPlot.js
+++ b/static/js/visualizations/createScatterPlot.js
@@ -16,10 +16,11 @@
  *
  */
 
-define (['jquery', 'd3', 'vizhelpers'],
-function($, d3, vizhelpers) {
+define (['jquery', 'd3', 'd3textwrap', 'vizhelpers'],
+function($, d3, d3textwrap, vizhelpers) {
 
     var helpers = Object.create(vizhelpers, {});
+
     var selex_active = false;
     var zoom_status = {
         translation: null,
@@ -252,7 +253,6 @@ function($, d3, vizhelpers) {
                     brush.clear();
                     // Remove brush event listener plot area
                     plot_area.selectAll('.brush').remove();
-
                 }
             };
 
@@ -266,12 +266,10 @@ function($, d3, vizhelpers) {
                 $('#save-cohort-' + plot_id + '-modal input[name="samples"]').attr('value', sample_list);
                 var topVal = Math.min((yScale(extent[1][1]) + 180),(height-$('.save-cohort-card').height()));
                 var leftVal = Math.min((xScale(extent[1][0])+ 40),(width-$('.save-cohort-card').width()));
-                $(svg[0]).parents('.plot')
-                    .find('.save-cohort-card').show()
+                $('.save-cohort-card').show()
                     .attr('style', 'position:absolute; top: '+ topVal +'px; left:' +leftVal+'px;');
 
-                $(svg[0]).parents('.plot')
-                    .find('.save-cohort-card').find('.btn').prop('disabled', (total_samples <= 0));
+                $('.save-cohort-card').find('.btn').prop('disabled', (total_samples <= 0));
             }
 
             function resize() {

--- a/static/js/visualizations/plotFactory.js
+++ b/static/js/visualizations/plotFactory.js
@@ -339,6 +339,8 @@ define([
     function select_plot(args){//plot_selector, legend_selector, pairwise_element, type, x_attr, y_attr, color_by, cohorts, cohort_override, data){
         var width  = $('.worksheet.active .worksheet-panel-body:first').width(), //TODO should be based on size of screen
             height = 725, //TODO ditto
+            // Top margin: required to keep top-most Y-axis ticks from being cut off on non-scrolled y axes
+            // Bottom margin: takes into account double-wrapped x-axis title and wrapped long-text x-axis labels
             margin = {top: 15, bottom: 150, left: 70, right: 10},
             x_type = '',
             y_type = '';

--- a/static/js/visualizations/plotFactory.js
+++ b/static/js/visualizations/plotFactory.js
@@ -362,7 +362,6 @@ define([
 
             data = data['items'];
 
-
             if (args.cohort_override) {
                 args.color_by = 'cohort';
             } else {

--- a/static/js/visualizations/plotFactory.js
+++ b/static/js/visualizations/plotFactory.js
@@ -339,7 +339,7 @@ define([
     function select_plot(args){//plot_selector, legend_selector, pairwise_element, type, x_attr, y_attr, color_by, cohorts, cohort_override, data){
         var width  = $('.worksheet.active .worksheet-panel-body:first').width(), //TODO should be based on size of screen
             height = 725, //TODO ditto
-            margin = {top: 0, bottom: 150, left: 70, right: 10},
+            margin = {top: 15, bottom: 150, left: 70, right: 10},
             x_type = '',
             y_type = '';
 

--- a/static/js/workbooks.js
+++ b/static/js/workbooks.js
@@ -656,6 +656,9 @@ require([
      * generate plot upon user click
      */
     $('.update-plot').on('click', function(event){
+        if($('.toggle-selection').hasClass('active')) {
+            $('.toggle-selection').click();
+        }
         if(valid_plot_settings($(this).parent())) {
             var data = get_plot_info_on_page($(this).parent());
             update_plot_model(workbook_id, data.worksheet_id, data.plot_id, data.attrs, data.selections, function(result){

--- a/static/js/workbooks.js
+++ b/static/js/workbooks.js
@@ -136,6 +136,9 @@ require([
     }
 
     $('.show-settings-flyout').on('click', function () {
+        if($('.toggle-selection').hasClass('active')) {
+            $('.toggle-selection').click();
+        }
         show_plot_settings();
     });
 


### PR DESCRIPTION
- Scaling (aka zoom in and out via scroll wheel and double-click) is disabled on any plot with an ordinal/categorical axis (cubbyhole, bar graph, violin) pending a solution to d3's lack of support for ordinal zoom which doesn't also break tooltips
- Fixed some panning behaviors related to the above
- Opening/closing the analysis settings flyout will now disable sample selection, as will clicking the 'update plot' button in the analysis settings flyout