### PR TITLE
Cohort Models migration

### DIFF
--- a/GenespotRE/views.py
+++ b/GenespotRE/views.py
@@ -231,7 +231,7 @@ def user_landing(request):
 
     users = User.objects.filter(is_superuser=0)
     cohort_perms = Cohort_Perms.objects.filter(user=request.user).values_list('cohort', flat=True)
-    cohorts = Cohort.objects.filter(id__in=cohort_perms, active=True).order_by('-last_date_saved').annotate(num_patients=Count('samples'))
+    cohorts = Cohort.objects.filter(id__in=cohort_perms, active=True).order_by('-last_date_saved').annotate(num_cases=Count('samples__case_barcode'))
 
     for item in cohorts:
         item.perm = item.get_perm(request).get_perm_display()

--- a/scripts/add_alldata_cohort.py
+++ b/scripts/add_alldata_cohort.py
@@ -1,6 +1,6 @@
 """
 
-Copyright 2015, Institute for Systems Biology
+Copyright 2016, Institute for Systems Biology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -160,18 +160,15 @@ def get_superuser_id(conn, superuser_name):
 def get_sample_barcodes(conn):
     logging.info("Getting list of sample barcodes from MySQL")
     cursor = conn.cursor(DictCursor)
-    select_samples_str = 'SELECT distinct SampleBarcode from metadata_samples where Project="TCGA";'
+    select_samples_str = "SELECT distinct SampleBarcode, ParticipantBarcode from metadata_samples where Project='TCGA';"
     cursor.execute(select_samples_str)
     rows = cursor.fetchall()
     cursor.close()
-    return rows
-
-def get_patient_barcodes(conn):
-    cursor = conn.cursor(DictCursor)
-    select_patients_str = 'SELECT DISTINCT ParticipantBarcode from metadata_samples where Project="TCGA";'
-    cursor.execute(select_patients_str)
-    rows = cursor.fetchall()
-    cursor.close()
+    # TODO: Temporary shim until Project/Study IDs are in metadata_samples
+    for row in rows:
+        row['project_id'] = None
+        row['sample_barcode'] = row['SampleBarcode']
+        row['patient_barocde'] = row['ParticipantBarcode']
     return rows
 
 def get_barcodes_from_file(filename):
@@ -213,9 +210,8 @@ def create_tcga_cohorts_from_files(directory):
         file_barcodes = get_barcodes_from_file(filepath)
         print filepath, len(file_barcodes['sample_barcodes']), len(file_barcodes['patient_barcodes'])
 
-def insert_barcodes_mysql(conn, superuser_id, cohort_name, sample_barcodes, patient_barcodes):
-    insert_samples_str = 'INSERT INTO cohorts_samples (sample_id, cohort_id) values (%s, %s);'
-    insert_patients_str = 'INSERT INTO cohorts_patients (patient_id, cohort_id) values (%s, %s);'
+def insert_barcodes_mysql(conn, superuser_id, cohort_name, sample_barcodes):
+    insert_samples_str = 'INSERT INTO cohorts_samples (sample_barcode, cohort_id, case_barcode) values (%s, %s, %s);'
 
     insert_cohort_str = 'insert into cohorts_cohort (name, active, last_date_saved) values (%s, %s, %s);'
     insert_cohort_tuple = (cohort_name, True, datetime.datetime.now())
@@ -240,17 +236,10 @@ def insert_barcodes_mysql(conn, superuser_id, cohort_name, sample_barcodes, pati
 
     sample_tuples = []
     for row in sample_barcodes:
-        sample_tuples.append((row['SampleBarcode'], str(cohort_id)))
+        sample_tuples.append((row['SampleBarcode'], str(cohort_id), row['ParticipantBarcode'],))
     logging.info('Number of sample barcodes: {num_samples}'.format(num_samples=len(sample_tuples)))
 
     cursor.executemany(insert_samples_str, sample_tuples)
-
-    patients_tuples = []
-    for row in patient_barcodes:
-        if row['ParticipantBarcode'] != '':
-            patients_tuples.append((row['ParticipantBarcode'], str(cohort_id)))
-    logging.info('Number of patient barcodes: {num_barcodes}'.format(num_barcodes=len(patients_tuples)))
-    cursor.executemany(insert_patients_str, patients_tuples)
 
     cursor.execute('insert into cohorts_cohort_perms (perm, cohort_id, user_id) values (%s, %s, %s)', ('OWNER', cohort_id, superuser_id))
     conn.commit()
@@ -268,7 +257,7 @@ def authorize_and_get_bq_service():
 def create_bq_cohort(project_id, dataset_id, table_id, cohort_id, sample_barcodes):
     service = authorize_and_get_bq_service()
     bqs = BigQueryCohortSupport(service, project_id, dataset_id, table_id)
-    bqs.add_cohort_with_sample_barcodes(cohort_id, sample_barcodes)
+    bqs.add_cohort_to_bq(cohort_id, sample_barcodes)
 
 def main():
     cmd_line_parser = ArgumentParser(description="Full sample set cohort utility")
@@ -286,7 +275,6 @@ def main():
 
     conn = get_mysql_connection()
     sample_barcodes = get_sample_barcodes(conn)
-    patient_barcodes = get_patient_barcodes(conn)
 
     cohort_id = None
 
@@ -307,13 +295,12 @@ def main():
             exit(1)
 
         logging.info("Superuser ID: {sid}".format(sid=superuser_id))
-        cohort_id = insert_barcodes_mysql(conn, superuser_id, args.cohort_name, sample_barcodes, patient_barcodes)
+        cohort_id = insert_barcodes_mysql(conn, superuser_id, args.cohort_name, sample_barcodes)
     else:
         cohort_id = args.cohort_id
 
     if do_bigquery:
-        sample_barcode_list = [x['SampleBarcode'] for x in sample_barcodes]
-        create_bq_cohort(project_id, args.dataset, args.table_name, cohort_id, sample_barcode_list)
+        create_bq_cohort(project_id, args.dataset, args.table_name, cohort_id, sample_barcodes)
 
 if __name__ == "__main__":
     main()

--- a/scripts/userdata_bootstrap.py
+++ b/scripts/userdata_bootstrap.py
@@ -276,7 +276,7 @@ def bootstrap_user_data_schema(public_feature_table, big_query_dataset, bucket_n
                                                      public_feature_table, bqdataset_id))
         db.commit()
 
-        # Compare the number of studies in projects_user_data_tables, projects_study, and our study set.
+        # Compare the number of studies in projects_user_data_tables, projects_project, and our study set.
         # If they don't match, something might be wrong.
         study_count = 0
         study_udt_count = 0
@@ -321,7 +321,7 @@ def bootstrap_file_data():
                                    "SELECT %s,%s,datafilenamekey from metadata_data " \
                                    "    where datafileuploaded='true' and datafilenamekey!='' and project=%s;"
 
-    update_projects_study = "UPDATE projects_user_data_tables set data_upload_id=%s where project_id=%s;"
+    update_projects_project = "UPDATE projects_user_data_tables set data_upload_id=%s where project_id=%s;"
     get_studies = "SELECT * FROM projects_project;"
     get_last_userupload = "SELECT * FROM data_upload_userupload order by id desc limit 1;"
 
@@ -342,7 +342,7 @@ def bootstrap_file_data():
             last_userupload = cursor.fetchone()
 
             # Update the projects_project table with new upload id
-            cursor.execute(update_projects_study, (last_userupload[0], project['id']))
+            cursor.execute(update_projects_project, (last_userupload[0], project['id']))
 
 
             if project['name'] != 'CCLE': # TCGA

--- a/seqpeek/views.py
+++ b/seqpeek/views.py
@@ -32,7 +32,7 @@ from visualizations.models import SavedViz, Plot, Plot_Cohorts, Viz_Perms
 
 SEQPEEK_VIEW_DEBUG_MODE = False
 
-SAMPLE_ID_FIELD_NAME = 'sample_id'
+SAMPLE_ID_FIELD_NAME = 'sample_barcode'
 TRACK_ID_FIELD = "tumor"
 COORDINATE_FIELD_NAME = 'uniprot_aapos'
 PROTEIN_ID_FIELD = 'uniprot_id'

--- a/static/js/helpers/search_helpers.js
+++ b/static/js/helpers/search_helpers.js
@@ -94,7 +94,7 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
             attr_counts = metadata_counts['count'];
 
             $('#isb-cgc-data-total-samples').html(metadata_counts['total']);
-            $('#isb-cgc-data-total-participants').html(metadata_counts['participants']);
+            $('#isb-cgc-data-total-participants').html(metadata_counts['cases']);
             $('#user-data-total-samples').html(user_data && metadata_counts['user_data_total'] !== null ? metadata_counts['user_data_total'] : "NA");
             $('#user-data-total-participants').html(user_data && metadata_counts['user_data_participants'] !== null ? metadata_counts['user_data_participants'] : "NA");
 
@@ -183,7 +183,7 @@ function($, tree_graph, stack_bar_chart, draw_parsets) {
                     console.debug("[BENCHMARKING] Time for response in update_counts_parsets: "+(stopReq-startReq)+ "ms");
                     attr_counts = results['count'];
                     $('#isb-cgc-data-total-samples').html(results['total']);
-                    $('#isb-cgc-data-total-participants').html(results['participants']);
+                    $('#isb-cgc-data-total-participants').html(results['cases']);
                     $('#user-data-total-samples').html(results['user_data'] && results['user_data_total'] !== null ? results['user_data_total'] : "NA");
                     $('#user-data-total-participants').html(results['user_data'] && results['user_data_participants'] !== null ? results['user_data_participants'] : "NA");
                     context.update_filter_counts(attr_counts);

--- a/static/js/seqpeek_view/view.js
+++ b/static/js/seqpeek_view/view.js
@@ -49,7 +49,7 @@ function (
         var AMINO_ACID_WILDTYPE_FIELD_NAME = "amino_acid_wildtype";
         var DNA_CHANGE_FIELD_NAME = "dna_change";
 
-        var SAMPLE_ID_FIELD_NAME = "sample_id";
+        var SAMPLE_ID_FIELD_NAME = "sample_barcode";
 
         var DNA_CHANGE_KEY_FN = function(data_point) {
             var id = data_point[DNA_CHANGE_FIELD_NAME];

--- a/static/js/visualizations/createCubbyPlot.js
+++ b/static/js/visualizations/createCubbyPlot.js
@@ -262,6 +262,8 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
                 }
             };
 
+            var zoom_none = function() { return;};
+
             var zoom = null;
 
             if (width > view_width && height> view_height) {
@@ -281,6 +283,13 @@ function($, d3, d3tip, d3textwrap, vizhelpers) {
                     .y(y2)
                     .scaleExtent([1,1])
                     .on('zoom', zoom_y);
+            } else {
+                zoom = d3.behavior.zoom()
+                    .x(x2)
+                    .scaleExtent([1,1])
+                    .y(y2)
+                    .scaleExtent([1,1])
+                    .on('zoom',zoom_none);
             }
 
             svg.call(zoom);

--- a/templates/GenespotRE/user_landing.html
+++ b/templates/GenespotRE/user_landing.html
@@ -87,7 +87,7 @@
                                     <tr>
                                         <td class="checkbox-col"><input type="checkbox" name="id" value="{{ cohort.id }}" title="{{ cohort.name }} Checkbox" aria-label="cohort-checkbox"/></td>
                                         <td class="name-col"><a href="{% url 'cohort_details' cohort.id %}">{{ cohort.name }}</a></td>
-                                        <td class="sample-col">{{ cohort.num_patients }}</td>
+                                        <td class="sample-col">{{ cohort.num_cases }}</td>
                                         <td class="owner-col">{{ cohort.owner.email }}</td>
                                         <td class="date-col">{{ cohort.last_date_saved|date:'M d, Y, g:i a' }}</td>
                                     </tr>

--- a/templates/cohorts/cohort_list.html
+++ b/templates/cohorts/cohort_list.html
@@ -92,8 +92,8 @@
                                     <input {% if cohort.id in previously_selected_cohort_ids %}checked{% endif %} type="checkbox" name="id" value="{{ cohort.id }}" title="Cohort {{ cohort.id }} checkbox" aria-label="cohort-checkbox"/>
                                 </td>
                                 <td class="name-col"><a href="{% url 'cohort_details' cohort.id %}" title="{{ cohort.name|wrap_text }}">{{ cohort.name }}</a></td>
-                                <td class="sample-col">{#{ cohort.num_patients }#} {{ cohort.sample_size }} </td>
-                                <td>{{ cohort.patient_size }}</td>
+                                <td class="sample-col"> {{ cohort.sample_size }} </td>
+                                <td>{{ cohort.case_size }}</td>
                                 <td class="owner-col">
                                     {% if cohort.perm == 'Owner' %}
                                         You
@@ -151,7 +151,7 @@
                                 </td>
                                 <td class="name-col"><a href="{% url 'cohort_details' cohort.id %}">{{ cohort.name }}</a></td>
                                 <td class="sample-col"> {{ cohort.sample_size }} </td>
-                                <td>{{ cohort.patient_size }}</td>
+                                <td>{{ cohort.case_size }}</td>
                                 <td class="date-col">{{ cohort.last_date_saved|date:'M d, Y, g:i a' }}</td>
                             </tr>
                             {% endif %}

--- a/templates/cohorts/isb-cgc-data.html
+++ b/templates/cohorts/isb-cgc-data.html
@@ -220,12 +220,12 @@
                                 <div class="row col-md-12 space-bottom-10">
                                     <span class="detail-label">Total Number of Samples:</span>
                                     <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                                    <span class="total-values" id="total-samples">{{ total_samples }}</span>
+                                    <span class="total-values" id="isb-cgc-data-total-samples">{{ total_samples }}</span>
                                 </div>
                                 <div class="row col-md-12 space-bottom-10">
                                     <span class="detail-label">Total Number of Participants:</span>
                                     <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                                    <span class="total-values" id="total-participants">{{ total_patients }}</span>
+                                    <span class="total-values" id="isb-cgc-data-total-participants">{{ total_cases }}</span>
                                 </div>
                                 <div class="row col-md-12 space-bottom-10">
                                     <span>Your Permissions: {{ cohort.perm.perm }}</span>
@@ -280,9 +280,9 @@
                                     <span class="total-values" id="isb-cgc-data-total-samples">{{ metadata_counts.total }}</span>
                                 </div>
                                 <div class="row col-md-6">
-                                    <span class="detail-label">Total Number of Participants:</span>
+                                    <span class="detail-label">Total Number of Cases:</span>
                                     <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
-                                    <span class="total-values" id="isb-cgc-data-total-participants">{{ metadata_counts.participants }}</span>
+                                    <span class="total-values" id="isb-cgc-data-total-participants">{{ metadata_counts.cases }}</span>
                                 </div>
                             </div>
                         </div>

--- a/templates/cohorts/user-data.html
+++ b/templates/cohorts/user-data.html
@@ -186,7 +186,7 @@
                         <span class="total-values" id="user-data-total-samples">{% if user_data %}{{ metadata_counts.user_data_total  }}{% else %}NA{% endif %}</span>
                     </div>
                     <div class="row col-md-6">
-                        <span class="detail-label">Total Number of Participants:</span>
+                        <span class="detail-label">Total Number of Cases:</span>
                         <div class="spinner" style="display:none;"><i class="fa fa-spinner fa-spin"></i></div>
                         <span class="total-values" id="user-data-total-participants">{% if user_data %}{{ metadata_counts.user_data_participants  }}{% else %}NA{% endif %}</span>
                     </div>

--- a/visualizations/plot_factory.py
+++ b/visualizations/plot_factory.py
@@ -60,10 +60,10 @@ class PlotFactory(object):
             return data
 
     @staticmethod
-    def union_cohort_samples_patients(cohort_ids):
-        cohort_patients = Patients.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('patient_id', flat=True)
-        cohort_samples = Samples.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('sample_id', flat=True)
-        return cohort_samples, cohort_patients
+    def union_cohort_samples_cases(cohort_ids):
+        cohort_cases = Samples.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('case_barcode', flat=True)
+        cohort_samples = Samples.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('sample_barcode', flat=True)
+        return cohort_samples, cohort_cases
 
     @classmethod
     def generate_generic_plot(cls, title, cohort):
@@ -93,8 +93,8 @@ class PlotFactory(object):
                         'name': cohort.name.encode('utf-8')
                     }],
                 'cohort_name': str(cohort.name),
-                'patient_length': len(cohort.patients_set.all()),
-                'sample_length': len(cohort.samples_set.all()),
+                'patient_length': len(cohort.case_size()),
+                'sample_length': len(cohort.samples_size()),
         }
 
         plots_data.append(item)

--- a/visualizations/views.py
+++ b/visualizations/views.py
@@ -31,7 +31,7 @@ from django.core.urlresolvers import reverse
 from django.utils import formats
 
 from models import SavedViz, Plot, Plot_Cohorts, Viz_Perms, Plot_Comments
-from cohorts.models import Cohort, Cohort_Perms, Patients, Samples
+from cohorts.models import Cohort, Cohort_Perms, Samples
 from bq_data_access.feature_search.util import SearchableFieldHelper
 
 
@@ -71,10 +71,10 @@ def convert(data):
     else:
         return data
 
-def union_cohort_samples_patients(cohort_ids):
-    cohort_patients = Patients.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('patient_id', flat=True)
-    cohort_samples = Samples.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('sample_id', flat=True)
-    return cohort_samples, cohort_patients
+def union_cohort_samples_cases(cohort_ids):
+    cohort_cases = Samples.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('case_barcode', flat=True)
+    cohort_samples = Samples.objects.filter(cohort_id__in=cohort_ids).distinct().values_list('sample_barcode', flat=True)
+    return cohort_samples, cohort_cases
 
 friendly_name_map = {
     'disease_code':'Disease Code',
@@ -379,7 +379,7 @@ def genericplot(request, id=0):
         if viz:
             viz_perm = viz.get_perm(request)
             for plot in plots:
-                sample_set, patient_set = union_cohort_samples_patients(plot.plot_cohorts_set.all().values_list('cohort', flat=True))
+                sample_set, patient_set = union_cohort_samples_cases(plot.plot_cohorts_set.all().values_list('cohort', flat=True))
                 cohorts = Cohort.objects.filter(id__in=plot.plot_cohorts_set.all().values_list('cohort', flat=True))
                 # for c in plot.plot_cohorts_set.all():
                 #     cohorts.append(Cohort.objects.filter(id__in=)


### PR DESCRIPTION
- sample_id and case_id are now sample_barcode and case_barcode in cohorts_samples. These name changes have been propagated to most parts of WebApp, Common, and API, but will no doubt need extensive testing.
- The Patients model has been deleted from Cohorts/models.
- sample_barcode was converted to a CharField with a max length of 45 chars, and indexed
- fetch_isbcgc_study_set has been renamed to fetch_isbcgc_project_set, and the corresponding sproc has also been renamed to get_isbcgc_project_set
- Patient and Participant were renamed to 'case' in most places; this has been propagated but will need double-checking

Requires PR #74 from Common and #70 from API