### PR TITLE
SocialNetwork Login Failure

### DIFF
--- a/static/js/session_security.js
+++ b/static/js/session_security.js
@@ -174,8 +174,7 @@ define(['jquery',], function ($) {
         pingUrl: pingUrl,
         warnAfter: warnAfter,
         expireAfter: expireAfter,
-        confirmFormDiscard: confirmFormDiscard
+        confirmFormDiscard: confirmFormDiscard,
+        returnToUrl: BASE_URL
     });
-
-
 });


### PR DESCRIPTION
- Hopefully this will fix the last SocialNetwork Login Failure, which seems to be happening when SessionSecurity attempts to reload the page after the login has expired. Now the user will be redirected to our homepage where they'll have to log back in.