### PR TITLE
Maintenance mode tweaks

### DIFF
--- a/GenespotRE/templatetags/custom_tags.py
+++ b/GenespotRE/templatetags/custom_tags.py
@@ -356,6 +356,12 @@ def get_tooltip_text(value_id, attr):
 
 
 @register.filter
+def is_superuser(this_user):
+    isb_superuser = User.objects.get(username='isb')
+    return this_user.id == isb_superuser.id
+
+
+@register.filter
 def get_cohorts_this_user(this_user, is_active=True):
     isb_superuser = User.objects.get(username='isb')
     public_cohorts = Cohort_Perms.objects.filter(user=isb_superuser,perm=Cohort_Perms.OWNER).values_list('cohort', flat=True)

--- a/GenespotRE/views.py
+++ b/GenespotRE/views.py
@@ -19,6 +19,7 @@ import sys
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.models import User
 from django.db.models import Count
 from django.http import HttpResponse
@@ -100,6 +101,7 @@ def _decode_dict(data):
 Handles login and user creation for new users.
 Returns user to landing page.
 '''
+@never_cache
 def landing_page(request):
     return render(request, 'GenespotRE/landing.html',
                   {'request': request})

--- a/templates/share/site_header.html
+++ b/templates/share/site_header.html
@@ -11,7 +11,7 @@
             <div class="nav navbar-left">
                  <ul class="">
                     <li class="navbar-item">
-                        {% if user.is_authenticated %}
+                        {% if user.is_authenticated and not user|is_superuser %}
                              <a href="{% url 'dashboard' %}" title="Dashboard" >
                         {%  else %}
                             <a href="{% url 'landing_page' %}" title="Home Page" >
@@ -37,7 +37,7 @@
             </div>
 
             <div class="nav navbar-right">
-                {% if user.is_authenticated %}
+                {% if user.is_authenticated and not user|is_superuser %}
                     <div id="user-login" class="navbar-item">
                         <a class="avatar-link" href="{% url 'user_detail' user.id %}">
                             <img src="{{ user.socialaccount_set.all.0.get_avatar_url }}" width="32" height="32" alt="Avatar Link to User Details">
@@ -69,7 +69,7 @@
             </div>
         </div>
     </nav>
-    {% if user.is_authenticated %}
+    {% if user.is_authenticated and not user|is_superuser %}
     <nav class="nav subnav collapse" role="navigation" id="subnav">
         <ul class="container">
             {% if user.is_authenticated %}


### PR DESCRIPTION
- When logged in as the Django admin the landing page should no longer try to show you things which require an actual user account
- Disabled caching of the landing page (this should hopefully prevent caching of the maintenance mode template)