### PR TITLE
Fix for issue 1906

### DIFF
--- a/static/js/data_upload.js
+++ b/static/js/data_upload.js
@@ -506,7 +506,7 @@ require([
         var textInputOk = true;
 
         var names = $('input#program-name').val() + ' ' + $('input#project-name').val();
-        var descs = $('input#project-description').val() + ' ' + $('input#program-description').val();
+        var descs = $('textarea#project-description').val() + ' ' + $('textarea#program-description').val();
 
         var unallowed_names = names.match(base.whitelist);
         var unallowed_descs = descs.match(base.whitelist);


### PR DESCRIPTION
Correctly catches non-whitelist characters, but the error message still does not show bizzare unicode characters if they are present.