### PR TITLE
Fix for 1929: changed span id to class

### DIFF
--- a/templates/projects/program_upload.html
+++ b/templates/projects/program_upload.html
@@ -17,7 +17,7 @@
         <h1 class="page-header">Data Upload</h1>
         <div id="unallowed-chars-alert" class="alert alert-warning alert-dismissable" style="display: none;">
             <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-            Your <span class="unallowed-fields"></span> contain invalid characters (<span id="unallowed-chars"></span>). Please choose different <span class="unallowed-fields"></span>.
+            Your <span class="unallowed-fields"></span> contain invalid characters (<span class="unallowed-chars"></span>). Please choose different <span class="unallowed-fields"></span>.
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Span was tagged with id instead of class, so jQuery could not find it.