### PR TITLE
Sprint 21

### DIFF
--- a/GenespotRE/settings.py
+++ b/GenespotRE/settings.py
@@ -532,3 +532,23 @@ EMAIL_SERVICE_API_KEY = os.environ.get('EMAIL_SERVICE_API_KEY', '')
 NOTIFICATION_EMAIL_FROM_ADDRESS = os.environ.get('NOTIFICATOON_EMAIL_FROM_ADDRESS', '')
 
 WHITELIST_RE = ur'([^\\\_\|\"\+~@:#\$%\^&\*=\-\.,\(\)0-9a-zA-Z\s\xc7\xfc\xe9\xe2\xe4\xe0\xe5\xe7\xea\xeb\xe8\xef\xee\xed\xec\xc4\xc5\xc9\xe6\xc6\xf4\xf6\xf2\xfb\xf9\xd6\xdc\xe1\xf3\xfa\xf1\xd1\xc0\xc1\xc2\xc3\xc8\xca\xcb\xcc\xcd\xce\xcf\xd0\xd2\xd3\xd4\xd5\xd8\xd9\xda\xdb\xdd\xdf\xe3\xf0\xf5\xf8\xfd\xfe\xff])'
+
+if DEBUG and bool(os.environ.get('DEBUG_TOOLBAR', '') == 'True'):
+    INSTALLED_APPS += ('debug_toolbar',)
+    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+    DEBUG_TOOLBAR_PANELS = [
+        'debug_toolbar.panels.versions.VersionsPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
+        'debug_toolbar.panels.settings.SettingsPanel',
+        'debug_toolbar.panels.headers.HeadersPanel',
+        'debug_toolbar.panels.request.RequestPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
+        'debug_toolbar.panels.cache.CachePanel',
+        'debug_toolbar.panels.signals.SignalsPanel',
+        'debug_toolbar.panels.logging.LoggingPanel',
+        'debug_toolbar.panels.redirects.RedirectsPanel',
+    ]
+    SHOW_TOOLBAR_CALLBACK = True
+    INTERNAL_IPS = (os.environ.get('INTERNAL_IP', ''),)

--- a/GenespotRE/urls.py
+++ b/GenespotRE/urls.py
@@ -67,3 +67,9 @@ if settings.IS_DEV:
 
 if settings.NIH_AUTH_ON:
     urlpatterns.append(url(r'^demo/', include('demo.urls', namespace='demo')))
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns

--- a/genes/urls.py
+++ b/genes/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import views
 

--- a/seqpeek/urls.py
+++ b/seqpeek/urls.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 import views
 
 urlpatterns = [

--- a/shell/install-deps.sh
+++ b/shell/install-deps.sh
@@ -41,6 +41,10 @@ if [ -z "$CI" ]; then
     rm -rf "${HOMEROOT}/lib/*"
 fi
 pip install -q -r ${HOMEROOT}/requirements.txt -t ${HOMEROOT}/lib --upgrade --only-binary all
+if [ "$DEBUG" = "True"] && [ "$DEBUG_TOOLBAR" = "True"]; then
+    pip install -q django-debug-toolbar -t ${HOMEROOT}/lib --only-binary all
+fi
+
 echo "Libraries Installed"
 
 # Install SASS

--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -954,7 +954,7 @@ require([
 
     // Event handlers for the 'x' of the case and data type filter tokens
     $('.tab-content, #selected-filters').on('click', 'a.mol-cat-filter-x', function (e,data) {
-        var activeDataTab = $(this).parents('.data-tab').attr('id');
+        var activeDataTab = $(this).parents('span').data('prog-id')+'-data';
         var selFilterPanel = '.'+activeDataTab+ '-selected-filters';
         var createFormFilterSet = $('p#'+activeDataTab+'-filters');
 
@@ -993,7 +993,7 @@ require([
 
     // Handler for the 'x' of the mutation filter tokens
     $('.tab-content, #selected-filters').on('click', 'a.delete-x', function(e,data) {
-        var activeDataTab = $(this).parents('.data-tab').attr('id');
+        var activeDataTab = $(this).parents('span').data('prog-id')+'-data';
         var selFilterPanel = '.'+activeDataTab+ '-selected-filters';
         var createFormFilterSet = $('p#'+activeDataTab+'-filters');
 

--- a/variables/urls.py
+++ b/variables/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import views
 

--- a/visualizations/urls.py
+++ b/visualizations/urls.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import views, feature_access_views, feature_access_views_v2, data_access_views, data_access_views_v2
 

--- a/workbooks/urls.py
+++ b/workbooks/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import views
 


### PR DESCRIPTION
- For debugging in general, django_debug_toolbar is now available as an optional installation (requires DEBUG=True and DJANGO_TOOLBAR=True and INTERNAL_IP in .env)
- Various templates improvements per #1980
- Another fix for #2062
