### PR TITLE
Sprint 21

### DIFF
--- a/static/js/cohort_barcodes_details.js
+++ b/static/js/cohort_barcodes_details.js
@@ -286,7 +286,7 @@ require([
                         }
                     // GDC TSV case manifest
                     } else if(isGdcTsv) {
-                        if(!(fr.result.match(/\t/g).length > 2)) {
+                        if(!(fr.result.match(/\t/g).length >= 2)) {
                             msg = "This file is not in a valid GDC TSV case manifest format. Please double-check the file, and be sure the header row, Project column, and Case ID column were included."
                         }
                     // tab/comma delimited barcode list

--- a/static/js/cohort_barcodes_details.js
+++ b/static/js/cohort_barcodes_details.js
@@ -286,7 +286,7 @@ require([
                         }
                     // GDC TSV case manifest
                     } else if(isGdcTsv) {
-                        if(!(fr.result.match(/\t/g).length >= 1)) {
+                        if(!(fr.result.match(/\t/g).length >= 2)) {
                             msg = "This file is not in a valid GDC TSV case manifest format. Please double-check the file, and be sure the header row, Project column, and Case ID column were included."
                         }
                     // tab/comma delimited barcode list

--- a/static/js/cohort_barcodes_details.js
+++ b/static/js/cohort_barcodes_details.js
@@ -286,7 +286,7 @@ require([
                         }
                     // GDC TSV case manifest
                     } else if(isGdcTsv) {
-                        if(!fr.result.match(/\t/g).length > 2) {
+                        if(!(fr.result.match(/\t/g).length > 2)) {
                             msg = "This file is not in a valid GDC TSV case manifest format. Please double-check the file, and be sure the header row, Project column, and Case ID column were included."
                         }
                     // tab/comma delimited barcode list

--- a/static/js/cohort_barcodes_details.js
+++ b/static/js/cohort_barcodes_details.js
@@ -286,7 +286,7 @@ require([
                         }
                     // GDC TSV case manifest
                     } else if(isGdcTsv) {
-                        if(!(fr.result.match(/\t/g).length >= 2)) {
+                        if(!(fr.result.match(/\t/g).length >= 1)) {
                             msg = "This file is not in a valid GDC TSV case manifest format. Please double-check the file, and be sure the header row, Project column, and Case ID column were included."
                         }
                     // tab/comma delimited barcode list

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -281,7 +281,7 @@
                     </div>
                     <div class="modal-footer">
                         {% csrf_token %}
-                        <input type="submit" value="Exprt Cohort" class="btn btn-primary" />
+                        <input type="submit" value="Export Cohort" class="btn btn-primary" />
                         <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
                         <div id="exporting-cohort" class="collapse" style="display: none;">
                             <i class="fa fa-circle-o-notch fa-spin"></i>  Exporting Cohort...

--- a/templates/cohorts/new_cohort_barcodes.html
+++ b/templates/cohorts/new_cohort_barcodes.html
@@ -106,7 +106,7 @@ TARGET-51-PAJMFS,"", "TARGET"</pre>
                                 <a name="gdc-manifest"></a><h5>GDC Data Portal Case Manifest Files</h5>
                                 <p>GDC Data Portal case manifests can be obtained on the <a target="_BLANK" href="https://portal.gdc.cancer.gov/exploration">'Cases' tab of the Exploration section of the data portal.</a></p>
                                 <p>JSON case manifests must have a .json extension, and will be validated against the GDC's JSON schema. The minimum required properties for each entry in the JSON file are the <span class="code">project</span> object and the <span class="code">submitter_id</span> field. The <span class="code">project</span> object must include the <span class="code">project_id</span> property. All other properties will be ignored.</p>
-                                <p>TSV case manifests must have a .tsv extension, and must contain the first 3 columns of the GDC TSV case manifest in the following order: Case UUID, Case ID, Project. Any other columns will be ignored. <b><i>Do not remove the header row of the TSV case manifest.</i></b></p>
+                                <p>TSV case manifests must have a .tsv extension, and must contain the Case ID and Project columns. Any other columns will be ignored. <b><i>Do not remove the header row of the TSV case manifest.</i></b> Please note that currently, TSV case manifests will only contain the current page of the 'Cases' Exploration tab.</p>
                                 <p>Because the GDC Data Portal case manifest entries are cases, all samples from a case will be included in the cohort.</p>
                             </div>
                             <hr>


### PR DESCRIPTION
-> Fix for #1847: allow GDC data portal columns to be in any order, and only require Case ID and Project
