### PR TITLE
#2165

### DIFF
--- a/bq_data_access/v2/gexp_data.py
+++ b/bq_data_access/v2/gexp_data.py
@@ -54,7 +54,7 @@ class GEXPFeatureDef(object):
 
     regex = re_compile("^v2:GEXP:"
                        # gene
-                       "([a-zA-Z0-9\-\.]+):"
+                       "([a-zA-Z0-9\-.]+):"
                        # genomic_build 
                        "mrna_(" + "|".join([build for build in config_instance.supported_genomic_builds]) +
                        ")$")

--- a/bq_data_access/v2/protein_data.py
+++ b/bq_data_access/v2/protein_data.py
@@ -41,7 +41,7 @@ class RPPAFeatureDef(object):
     config_instance = RPPADataSourceConfig.from_dict(BIGQUERY_CONFIG)
     regex = re_compile("^v2:RPPA:"
                        # gene
-                       "([a-zA-Z0-9\-]+):"
+                       "([a-zA-Z0-9.\-]+):"
                        # protein name
                        "([a-zA-Z0-9._\-]+):"
                        # table ID


### PR DESCRIPTION
- #2165: Fixed RPPA for genes with . in the name, removed unneeded \ in GEXP regex