### PR TITLE
Sprint 27

### DIFF
--- a/static/js/cohort_details.js
+++ b/static/js/cohort_details.js
@@ -261,6 +261,7 @@ require([
     var clear_mol_filters = function(btn) {
         btn.siblings('.build-mol-filter').attr('disabled','disabled');
         btn.parents('.list').find('.mutation-build').val('HG19');
+        btn.parents('.list').find('.mutation-build').trigger('change');
         btn.parents('.list').find('.sel-gene a.close').click();
         btn.parents('.list').find('.mutation-category-selector').val("label");
         btn.parents('.list').find('.spec-molecular-attrs input').prop("checked",false);

--- a/templates/GenespotRE/dashboard.html
+++ b/templates/GenespotRE/dashboard.html
@@ -135,11 +135,17 @@
                                        <span class="list-title" title="{{ cohort.name|wrap_text }}">{{ cohort.name }}</span>
                                    </div>
                                </a>
+                               {% if not cohort.only_user_data %}
                                <a href="{% url 'cohort_filelist' cohort.id %}">
                                    <div class="list-link">
                                        <span class="list-title file-browser-link" title="Browse this cohort's file manifest">File browser</span>
                                    </div>
                                </a>
+                               {% else %}
+                                   <div class="list-link">
+                                       <span class="list-title file-browser-link" title="File browsing is unavailable for cohorts which contain only user data.">File Browser</span>
+                                   </div>
+                               {% endif %}
                                <div class="list-info col-3">
                                    <span>{{ cohort.last_date_saved|date:'M d, Y, g:i a' }}</span>
                                </div>


### PR DESCRIPTION
- Fix for Dashboard link to File Browser when a cohort is UDU-only
- Filter builder clear button will now reset the table display