### PR TITLE
Sprint 31

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,9 +6,6 @@ Vagrant.configure(2) do |config|
   # WebApp ports
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 8000, host: 8000
-  # API ports
-  config.vm.network "forwarded_port", guest: 8090, host: 8090
-  config.vm.network "forwarded_port", guest: 9000, host: 9000
 
   config.vm.synced_folder ".", "/home/vagrant/www"
   config.vm.synced_folder "../", "/home/vagrant/parentDir"
@@ -18,10 +15,6 @@ Vagrant.configure(2) do |config|
 
   # Map Common and lib for API
   config.vm.synced_folder "../ISB-CGC-Common", "/home/vagrant/parentDir/ISB-CGC-API/ISB-CGC-Common"
-  config.vm.synced_folder "../ISB-CGC-WebApp/lib", "/home/vagrant/parentDir/ISB-CGC-API/lib"
-
-  # Map Common for Cron
-  config.vm.synced_folder "../ISB-CGC-Common", "/home/vagrant/parentDir/ISB-CGC-Cron/ISB-CGC-Common"
 
   config.vm.provision "shell", path: 'shell/install-deps.sh'
   config.vm.provision "shell", path: 'shell/create-database.sh'

--- a/bq_data_access/data_types/mirna.py
+++ b/bq_data_access/data_types/mirna.py
@@ -11,7 +11,7 @@ BIGQUERY_CONFIG = {
             "internal_table_id": "tcga_hg19_mirna_rpm"
         },
         {
-            "table_id": "isb-cgc:TCGA_hg38_data_v0.miRNA_Expression_r11_180816",
+            "table_id": "isb-cgc:TCGA_hg38_data_v0.miRNA_Expression",
             "mirna_id_field": "mirna_id",
             "value_label": "RPM",
             "value_field": "reads_per_million_miRNA_mapped",
@@ -20,7 +20,7 @@ BIGQUERY_CONFIG = {
             "internal_table_id": "tcga_hg38_mirna_rpm"
         },
         {
-            "table_id": "isb-cgc:TARGET_hg38_data_v0.miRNA_Expression_r11_180816",
+            "table_id": "isb-cgc:TARGET_hg38_data_v0.miRNA_Expression",
             "mirna_id_field": "mirna_id",
             "value_label": "RPM",
             "value_field": "reads_per_million_miRNA_mapped",

--- a/bq_data_access/data_types/mirna.py
+++ b/bq_data_access/data_types/mirna.py
@@ -11,7 +11,7 @@ BIGQUERY_CONFIG = {
             "internal_table_id": "tcga_hg19_mirna_rpm"
         },
         {
-            "table_id": "isb-cgc:TCGA_hg38_data_v0.miRNA_Expression",
+            "table_id": "isb-cgc:TCGA_hg38_data_v0.miRNAseq_Expression",
             "mirna_id_field": "mirna_id",
             "value_label": "RPM",
             "value_field": "reads_per_million_miRNA_mapped",


### PR DESCRIPTION
- Swap to non-suffix miRNA expression tables in BQ
- Remove API and Cron from Vagrant build; they're getting their own VMs