### PR TITLE
adjustments for cohort table access

### DIFF
--- a/GenespotRE/settings.py
+++ b/GenespotRE/settings.py
@@ -81,7 +81,7 @@ CGHUB_CONTROLLED_DATA_BUCKET = os.environ.get('CGHUB_CONTROLLED_DATA_BUCKET', ''
 GCLOUD_BUCKET           = os.environ.get('GOOGLE_STORAGE_BUCKET')
 
 # BigQuery cohort storage settings
-BIGQUERY_COHORT_DATASET_ID           = os.environ.get('BIGQUERY_COHORT_DATASET_ID', 'cohort_dataset')
+BIGQUERY_COHORT_DATASET_ID           = os.environ.get('BIGQUERY_COHORT_DATASET_ID', 'cloud_deployment_cohorts')
 BIGQUERY_COHORT_TABLE_ID    = os.environ.get('BIGQUERY_COHORT_TABLE_ID', 'developer_cohorts')
 BIGQUERY_COSMIC_DATASET_ID    = os.environ.get('BIGQUERY_COSMIC_DATASET_ID', '')
 BIGQUERY_CGC_TABLE_ID    = os.environ.get('BIGQUERY_CGC_TABLE_ID', '')

--- a/bq_data_access/v2/data_access.py
+++ b/bq_data_access/v2/data_access.py
@@ -238,12 +238,11 @@ class FeatureVectorBigQueryBuilder(object):
     def build_from_django_settings(cls, bqss):
         from django.conf import settings as django_settings
         project_id_number = django_settings.BIGQUERY_PROJECT_ID
-        project_name = django_settings.GCLOUD_PROJECT_ID
         bigquery_cohort_dataset = django_settings.BIGQUERY_COHORT_DATASET_ID
         biquery_cohort_table = django_settings.BIGQUERY_COHORT_TABLE_ID
 
         cohort_table_id = "{project_name}:{dataset_id}.{table_id}".format(
-            project_name=project_name,
+            project_name=project_id_number,
             dataset_id=bigquery_cohort_dataset,
             table_id=biquery_cohort_table
         )


### PR DESCRIPTION
include BIGQUERY_PROJECT_ID instead of GCLOUD_PROJECT_ID as the project when cohort table is accessed.

change of bigquery_cohort_dataset_id default value from 'cohort_dataset' to 'cloud_deployment_cohorts'