### PR TITLE
Limit number of datasets that can be registered with service account

### DIFF
--- a/blink_sass/pages/_users.sass
+++ b/blink_sass/pages/_users.sass
@@ -120,6 +120,10 @@
         color: $isb-dark
         font-size: .9em
         font-style: italic
+    .dataset-limit-note
+        color: $danger-bgcolor-dark
+        font-size: .9em
+        font-style: italic
     .verify-register-sa-div
         >div
             padding: 10px 0

--- a/isb_cgc/settings.py
+++ b/isb_cgc/settings.py
@@ -543,6 +543,7 @@ DCF_GOOGLE_SA_MONITOR_URL                = os.environ.get('DCF_GOOGLE_SA_MONITOR
 DCF_GOOGLE_SA_URL                        = os.environ.get('DCF_GOOGLE_SA_URL', '')
 DCF_TOKEN_REFRESH_WINDOW_SECONDS         = int(os.environ.get('DCF_TOKEN_REFRESH_WINDOW_SECONDS', 86400))
 DCF_LOGIN_EXPIRATION_SECONDS             = int(os.environ.get('DCF_LOGIN_EXPIRATION_SECONDS', 86400))
+DCF_GOOGLE_SA_REGISTER_DATASETS_LIMIT    = int(os.environ.get('DCF_GOOGLE_SA_REGISTER_DATASETS_LIMIT', 6))
 
 ##############################
 #   Start django-finalware   #

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3314,6 +3314,10 @@ html {
     color: #676767;
     font-size: .9em;
     font-style: italic; }
+  #register-gcp .dataset-limit-note, #user-register-sa .dataset-limit-note, #user-adjust-sa .dataset-limit-note {
+    color: #D32F2F;
+    font-size: .9em;
+    font-style: italic; }
   #register-gcp .verify-register-sa-div > div, #user-register-sa .verify-register-sa-div > div, #user-adjust-sa .verify-register-sa-div > div {
     padding: 10px 0; }
   #register-gcp .verify-register-sa-div .verification-success:before, #user-register-sa .verify-register-sa-div .verification-success:before, #user-adjust-sa .verify-register-sa-div .verification-success:before {

--- a/static/js/register_sa.js
+++ b/static/js/register_sa.js
@@ -316,4 +316,18 @@ require([
         $('#verify-sa').submit();
     });
 
+    $('.dataset-list :checkbox').change(function()
+    {
+        var cnt_checked = $(".dataset-list input[type='checkbox']:checked").length;
+        if (cnt_checked > datasets_limit)
+        {
+            $('.dataset-limit-note').show();
+            $('.verify-sa-btn').prop( "disabled", true);
+        }
+        else
+        {
+            $('.dataset-limit-note').hide();
+            $('.verify-sa-btn').prop( "disabled", false);
+        }
+    });
 });

--- a/templates/isb_cgc/register_sa.html
+++ b/templates/isb_cgc/register_sa.html
@@ -55,6 +55,7 @@
 
                         <div id="datasets-select-div">
                             Which dataset(s) would you like to use?
+                            <p class="dataset-limit-note" hidden>*You can only register up to {{ datasets_limit }} datasets at one time. Try multiple requests for more datasets.</p>
                             <ul class="dataset-list">
                                 {% for dataset in authorized_datasets %}
                                     <li class="checkbox">
@@ -66,6 +67,7 @@
                                 {% endfor %}
                             </ul>
                         </div>
+
                         <input type="hidden" name="gcp_id" value="{{ gcp_id }}"/>
                         <div class="block">
                             <input type="submit" class="verify-sa-btn btn btn-primary" value="Verify Service Account Users"/>
@@ -196,4 +198,7 @@
 {% block js_file %}
 	{{ block.super }}
 	<script src="{% static 'js/register_sa.js' %}"></script>
+    <script type="text/javascript">
+    var datasets_limit = {{ datasets_limit|safe }};
+    </script>
 {% endblock %}


### PR DESCRIPTION
(Change for the webapp side)
Limit number of datasets that can be registered to service account per each request in the UI.
For ticket #2784 - The registration of 12+ more programs to controlled data causes error from DCF