### PR TITLE
Login hotfixes

### DIFF
--- a/isb_cgc/checkreqsize_middleware.py
+++ b/isb_cgc/checkreqsize_middleware.py
@@ -1,5 +1,5 @@
 ###
-# Copyright 2015-2019, Institute for Systems Biology
+# Copyright 2015-2024, Institute for Systems Biology
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/isb_cgc/forms.py
+++ b/isb_cgc/forms.py
@@ -1,0 +1,68 @@
+###
+# Copyright 2015-2024, Institute for Systems Biology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+import logging
+
+from allauth.account.forms import SignupForm, ChangePasswordForm, SetPasswordForm, ResetPasswordForm, LoginForm
+from allauth.socialaccount.models import SocialAccount
+from allauth.account.adapter import get_adapter
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.forms import ValidationError
+
+logger = logging.getLogger('main_logger')
+
+
+class CgcSignUp(SignupForm):
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        email = get_adapter().clean_email(email)
+        try:
+            user = User.objects.get(email=email)
+            SocialAccount.objects.get(user=user)
+            raise ValidationError("Please use Google login with this email address.")
+        except ObjectDoesNotExist as e:
+            logger.info("[STATUS] Email address {} not found as a social account - proceeding with local account creation.".format(email))
+            pass
+        return super(CgcSignUp, self).clean_email()
+
+
+class CgcResetPassword(ResetPasswordForm):
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        email = get_adapter().clean_email(email)
+        try:
+            user = User.objects.get(email=email)
+            SocialAccount.objects.get(user=user)
+            raise ValidationError("This is a Google account - the password cannot be reset from within this system.")
+        except ObjectDoesNotExist as e:
+            logger.info("[STATUS] User with address {} resetting password.".format(email))
+            pass
+        return super(CgcResetPassword, self).clean_email()
+
+
+class CgcLogin(LoginForm):
+    def clean(self):
+        email = self.user_credentials().get("email")
+        print(email)
+        try:
+            user = User.objects.get(email=email)
+            SocialAccount.objects.get(user=user)
+            raise ValidationError("Please log into this account using Google (above).")
+        except ObjectDoesNotExist as e:
+            logger.info("[STATUS] User with local account email address {} logging in.".format(email))
+            pass
+        return super(CgcLogin, self).clean()

--- a/isb_cgc/password_expiration.py
+++ b/isb_cgc/password_expiration.py
@@ -26,6 +26,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 logger = logging.getLogger('main_logger')
 
+
 class PasswordExpireMiddleware:
     """
     Adds Django message if password expires soon.

--- a/isb_cgc/settings.py
+++ b/isb_cgc/settings.py
@@ -519,6 +519,12 @@ ACCOUNTS_PASSWORD_EXPIRATION_WARN = os.environ.get('ACCOUNTS_PASSWORD_EXPIRATION
 ACCOUNTS_PASSWORD_HISTORY = os.environ.get('ACCOUNTS_PASSWORD_HISTORY', 5) # Max password history kept
 ACCOUNTS_ALLOWANCES = list(set(os.environ.get('ACCOUNTS_ALLOWANCES','').split(',')))
 
+ACCOUNT_FORMS = {
+    'reset_password': 'isb_cgc.forms.CgcResetPassword',
+    'signup': 'isb_cgc.forms.CgcSignUp',
+    'login': 'isb_cgc.forms.CgcLogin'
+}
+
 ##########################
 #   End django-allauth   #
 ##########################

--- a/isb_cgc/templatetags/custom_tags.py
+++ b/isb_cgc/templatetags/custom_tags.py
@@ -28,6 +28,7 @@ from django.template.defaulttags import register
 from cohorts.models import Cohort, Cohort_Perms
 from django.contrib.auth.models import User
 from django.db.models.query import QuerySet
+from allauth.socialaccount.models import SocialAccount
 from projects.models import Program
 from workbooks.models import Workbook
 import logging
@@ -110,6 +111,15 @@ def get_item(dictionary, key):
 @register.filter
 def get_account_email(account):
     return account.account.extra_data.get('email','None')
+
+
+@register.filter
+def account_is_social(user):
+    try:
+        SocialAccount.objects.get(user=user)
+    except ObjectDoesNotExist as e:
+        return False
+    return True
 
 
 @register.filter

--- a/templates/accounts/account/password_change.html
+++ b/templates/accounts/account/password_change.html
@@ -14,12 +14,20 @@
                 <form method="POST" action="{% url 'account_change_password' %}" class="password_change">
                     <div class="panel panel-default"></div>
                     <div class="panel panel-default">
+                    {% if user|account_is_social %}
+                    <div class="panel-body">
+                    <h4>
+                        Passwords cannot be changed for Google Accounts in this system.
+                    </h4>
+                    </div>
+                    {% else %}
                         <div class="panel-heading"><h3>{% trans "Change Password" %}</h3></div>
                         <div class="panel-body">
                             {% csrf_token %}
                             {{ form.as_p }}
                             <button class="btn btn-special" type="submit" name="action">{% trans "Change Password" %}</button>
                         </div>
+                    {% endif %}
                     </div>
                 </form>
             </div>

--- a/templates/accounts/account/password_set.html
+++ b/templates/accounts/account/password_set.html
@@ -11,6 +11,13 @@
             <div class="col-lg-4 col-md-4 col-sm-6 col-xs-8 password_set accounts-col">
                 <div class="panel panel-default"></div>
                 <div class="panel panel-default">
+                    {% if user|account_is_social %}
+                    <div class="panel-body">
+                    <h4>
+                        Passwords cannot be set for Google Accounts in this system.
+                    </h4>
+                    </div>
+                    {% else %}
                     <div class="panel-heading">
                         <h3>{% trans "Set Password" %}</h3>
                     </div>
@@ -21,6 +28,7 @@
                             <button class="btn btn-special" type="submit">{% trans "Set Password" %}</button>
                         </form>
                     </div>
+                    {% endif %}
                 </div>
             </div>
             <div class="col-lg-4 col-md-4 col-sm-3 col-xs-2"></div>


### PR DESCRIPTION
Local login hotfixes: 
* cannot reset, set, or change passwords for social accounts
* will be prompted to switch to Google login if attempting to sign up OR log in using a social account.